### PR TITLE
Add AgentOps tool call filters

### DIFF
--- a/routers/agent_ops.py
+++ b/routers/agent_ops.py
@@ -56,10 +56,16 @@ def get_agent_run(agent_run_id: int) -> AgentRunResponse:
 )
 def list_tool_calls_by_run(
     agent_run_id: int,
+    status: str | None = None,
+    tool_name: str | None = None,
+    error_type: str | None = None,
 ) -> list[ToolCallResponse]:
     tool_calls = list_tool_calls_by_run_service(
         agent_run_id=agent_run_id,
         tenant_id=MOCK_TENANT_ID,
+        status=status,
+        tool_name=tool_name,
+        error_type=error_type,
     )
 
     return [

--- a/services/agent_ops_service.py
+++ b/services/agent_ops_service.py
@@ -145,6 +145,9 @@ def get_tool_call(
 def list_tool_calls_by_run(
     agent_run_id: int,
     tenant_id: str,
+    status: str | None = None,
+    tool_name: str | None = None,
+    error_type: str | None = None,
 ) -> list[ToolCall]:
     # 确保 run 存在且属于当前 tenant。
     get_agent_run(
@@ -158,6 +161,15 @@ def list_tool_calls_by_run(
             .where(ToolCall.tenant_id == tenant_id)
             .where(ToolCall.agent_run_id == agent_run_id)
         )
+
+        if status is not None:
+            statement = statement.where(ToolCall.status == status)
+
+        if tool_name is not None:
+            statement = statement.where(ToolCall.tool_name == tool_name)
+
+        if error_type is not None:
+            statement = statement.where(ToolCall.error_type == error_type)
 
         tool_calls = session.exec(statement).all()
         return list(tool_calls)

--- a/tests/test_agent_ops_api.py
+++ b/tests/test_agent_ops_api.py
@@ -126,9 +126,15 @@ def test_list_tool_calls_by_run(monkeypatch):
     def fake_list_tool_calls_by_run_service(
         agent_run_id: int,
         tenant_id: str,
+        status: str | None = None,
+        tool_name: str | None = None,
+        error_type: str | None = None,
     ):
         calls["agent_run_id"] = agent_run_id
         calls["tenant_id"] = tenant_id
+        calls["status"] = status
+        calls["tool_name"] = tool_name
+        calls["error_type"] = error_type
 
         return [
             SimpleNamespace(
@@ -160,6 +166,9 @@ def test_list_tool_calls_by_run(monkeypatch):
 
     assert calls["agent_run_id"] == 1
     assert calls["tenant_id"] == "tenant_demo"
+    assert calls["status"] is None
+    assert calls["tool_name"] is None
+    assert calls["error_type"] is None
 
     assert len(data) == 1
     assert data[0]["id"] == 300
@@ -395,3 +404,67 @@ def test_get_agent_ops_metrics_summary(monkeypatch):
     assert data["approved_approval_requests"] == 1
     assert data["rejected_approval_requests"] == 1
     assert data["cancelled_approval_requests"] == 1
+
+
+def test_list_tool_calls_by_run_with_filters(monkeypatch):
+    calls = {}
+
+    def fake_list_tool_calls_by_run_service(
+        agent_run_id: int,
+        tenant_id: str,
+        status: str | None = None,
+        tool_name: str | None = None,
+        error_type: str | None = None,
+    ):
+        calls["agent_run_id"] = agent_run_id
+        calls["tenant_id"] = tenant_id
+        calls["status"] = status
+        calls["tool_name"] = tool_name
+        calls["error_type"] = error_type
+
+        return [
+            SimpleNamespace(
+                id=301,
+                agent_run_id=agent_run_id,
+                tenant_id=tenant_id,
+                tool_name="create_ticket",
+                tool_input_json='{"title":"VPN 连不上"}',
+                tool_output_json=None,
+                status="failed",
+                error_type="create_ticket_failed",
+                error_message="create ticket failed",
+                created_at=datetime(2026, 1, 1, 10, 0, 10),
+                finished_at=datetime(2026, 1, 1, 10, 0, 20),
+            )
+        ]
+
+    monkeypatch.setattr(
+        agent_ops_router,
+        "list_tool_calls_by_run_service",
+        fake_list_tool_calls_by_run_service,
+    )
+
+    response = client.get(
+        "/agent-ops/runs/1/tool-calls",
+        params={
+            "status": "failed",
+            "tool_name": "create_ticket",
+            "error_type": "create_ticket_failed",
+        },
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert calls["agent_run_id"] == 1
+    assert calls["tenant_id"] == "tenant_demo"
+    assert calls["status"] == "failed"
+    assert calls["tool_name"] == "create_ticket"
+    assert calls["error_type"] == "create_ticket_failed"
+
+    assert len(data) == 1
+    assert data[0]["id"] == 301
+    assert data[0]["status"] == "failed"
+    assert data[0]["tool_name"] == "create_ticket"
+    assert data[0]["error_type"] == "create_ticket_failed"

--- a/tests/test_agent_ops_service.py
+++ b/tests/test_agent_ops_service.py
@@ -235,6 +235,93 @@ def test_create_and_update_tool_call(agent_ops_test_engine):
     assert tool_calls[0].id == tool_call.id
 
 
+def test_list_tool_calls_by_run_with_filters(agent_ops_test_engine):
+    agent_run = agent_ops_service.create_agent_run(
+        AgentRunCreate(
+            tenant_id="tenant_demo",
+            user_id="user_demo",
+            input_message="VPN 连不上",
+            category="it",
+        )
+    )
+
+    agent_ops_service.create_tool_call(
+        ToolCallCreate(
+            agent_run_id=agent_run.id,
+            tenant_id="tenant_demo",
+            tool_name="search_kb",
+            status="success",
+            tool_input_json='{"query":"VPN 连不上"}',
+        )
+    )
+
+    agent_ops_service.create_tool_call(
+        ToolCallCreate(
+            agent_run_id=agent_run.id,
+            tenant_id="tenant_demo",
+            tool_name="classify_ticket",
+            status="failed",
+            error_type="classify_ticket_failed",
+            error_message="classification failed",
+            tool_input_json='{"message":"VPN 连不上"}',
+        )
+    )
+
+    agent_ops_service.create_tool_call(
+        ToolCallCreate(
+            agent_run_id=agent_run.id,
+            tenant_id="tenant_demo",
+            tool_name="create_ticket",
+            status="failed",
+            error_type="create_ticket_failed",
+            error_message="create ticket failed",
+            tool_input_json='{"title":"VPN 连不上"}',
+        )
+    )
+
+    failed_tool_calls = agent_ops_service.list_tool_calls_by_run(
+        agent_run_id=agent_run.id,
+        tenant_id="tenant_demo",
+        status="failed",
+    )
+
+    assert len(failed_tool_calls) == 2
+    assert {tool_call.status for tool_call in failed_tool_calls} == {"failed"}
+
+    search_kb_tool_calls = agent_ops_service.list_tool_calls_by_run(
+        agent_run_id=agent_run.id,
+        tenant_id="tenant_demo",
+        tool_name="search_kb",
+    )
+
+    assert len(search_kb_tool_calls) == 1
+    assert search_kb_tool_calls[0].tool_name == "search_kb"
+    assert search_kb_tool_calls[0].status == "success"
+
+    create_ticket_failed_tool_calls = agent_ops_service.list_tool_calls_by_run(
+        agent_run_id=agent_run.id,
+        tenant_id="tenant_demo",
+        error_type="create_ticket_failed",
+    )
+
+    assert len(create_ticket_failed_tool_calls) == 1
+    assert create_ticket_failed_tool_calls[0].tool_name == "create_ticket"
+    assert create_ticket_failed_tool_calls[0].error_type == "create_ticket_failed"
+
+    combined_filtered_tool_calls = agent_ops_service.list_tool_calls_by_run(
+        agent_run_id=agent_run.id,
+        tenant_id="tenant_demo",
+        status="failed",
+        tool_name="create_ticket",
+        error_type="create_ticket_failed",
+    )
+
+    assert len(combined_filtered_tool_calls) == 1
+    assert combined_filtered_tool_calls[0].tool_name == "create_ticket"
+    assert combined_filtered_tool_calls[0].status == "failed"
+    assert combined_filtered_tool_calls[0].error_type == "create_ticket_failed"
+
+
 def test_create_tool_call_with_missing_agent_run_should_return_404(agent_ops_test_engine):
     """
     测试尝试创建一个 tool call，但关联的 agent run 不存在，应该返回 404 错误。


### PR DESCRIPTION
## Summary

This PR adds query filters for AgentOps tool call records.

The endpoint:

```http
GET /agent-ops/runs/{agent_run_id}/tool-calls
```

now supports optional filters:

```http
?status=failed
?tool_name=create_ticket
?error_type=create_ticket_failed
```

## Changes

* Added optional `status`, `tool_name`, and `error_type` parameters to the AgentOps tool call API.
* Added dynamic filtering in `list_tool_calls_by_run`.
* Added API tests to verify query params are passed from router to service.
* Added service tests to verify database-level filtering by status, tool name, error type, and combined filters.

## Validation

Local test result:

```text
63 passed
```
