### PR TITLE
Distinguish empty RAG results from low relevance

### DIFF
--- a/rag_runtime/query_rag_chroma.py
+++ b/rag_runtime/query_rag_chroma.py
@@ -181,7 +181,7 @@ def generate_answer(question: str, context: str) -> str:
     """
     client = get_llm_client()
 
-    model = os.getenv("CHAT_MODEL", "qwen-plus")
+    model = os.getenv("CHAT_MODEL") or os.getenv("DASHSCOPE_MODEL", "qwen3.5-plus")
 
     system_prompt = """
 你是一个严谨的企业知识库问答助手。
@@ -246,6 +246,15 @@ def ask_rag(
     sources = build_sources(results)
 
     top_distance = results[0].distance if results else None
+
+    if not results:
+        return RagResponse(
+            question=question,
+            answer="我在已提供资料中没有找到足够依据。",
+            retrieval_status="no_context",
+            top_distance=None,
+            sources=[],
+        )
 
     if should_refuse(results, max_distance=max_distance):
         return RagResponse(

--- a/tests/test_query_rag_chroma.py
+++ b/tests/test_query_rag_chroma.py
@@ -1,0 +1,59 @@
+from rag_runtime import query_rag_chroma
+from rag_runtime.query_chroma import ChromaSearchResult
+
+
+def make_search_result(distance: float) -> ChromaSearchResult:
+    return ChromaSearchResult(
+        chunk_id="chunk_1",
+        document_id="doc_1",
+        title="Doc 1",
+        source_path="experiments/docs/doc_1.md",
+        chunk_index=0,
+        content="Useful support content.",
+        distance=distance,
+        tenant_id="tenant_demo",
+        category="it",
+    )
+
+
+def test_ask_rag_returns_no_context_without_results(monkeypatch):
+    monkeypatch.setattr(query_rag_chroma, "search_chroma", lambda **kwargs: [])
+
+    result = query_rag_chroma.ask_rag("missing answer")
+
+    assert result.retrieval_status == "no_context"
+    assert result.top_distance is None
+    assert result.sources == []
+
+
+def test_ask_rag_returns_low_relevance_when_top_distance_exceeds_threshold(monkeypatch):
+    monkeypatch.setattr(
+        query_rag_chroma,
+        "search_chroma",
+        lambda **kwargs: [make_search_result(distance=1.2)],
+    )
+
+    result = query_rag_chroma.ask_rag("weak answer", max_distance=0.9)
+
+    assert result.retrieval_status == "refused_low_relevance"
+    assert result.top_distance == 1.2
+    assert len(result.sources) == 1
+
+
+def test_ask_rag_returns_ok_when_retrieval_is_relevant(monkeypatch):
+    monkeypatch.setattr(
+        query_rag_chroma,
+        "search_chroma",
+        lambda **kwargs: [make_search_result(distance=0.4)],
+    )
+    monkeypatch.setattr(
+        query_rag_chroma,
+        "generate_answer",
+        lambda question, context: "Answer from context.",
+    )
+
+    result = query_rag_chroma.ask_rag("good answer", max_distance=0.9)
+
+    assert result.retrieval_status == "ok"
+    assert result.answer == "Answer from context."
+    assert result.top_distance == 0.4


### PR DESCRIPTION
## Summary

This PR finishes the RAG retrieval status cleanup.

## Included

- distinguish empty retrieval results from low relevance results
- return `no_context` when no chunks are retrieved
- keep `refused_low_relevance` for results above distance threshold
- preserve `CHAT_MODEL` / `DASHSCOPE_MODEL` fallback
- add focused `query_rag_chroma` tests

## Verification

- focused RAG tests passed locally