### PR TITLE
Add demo auth and tenant-scoped routing

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+
+DEFAULT_DEMO_USERS: dict[str, dict[str, str]] = {
+    "employee": {
+        "password": "employee",
+        "user_id": "user_demo",
+        "tenant_id": "tenant_demo",
+        "role": "employee",
+    },
+    "support": {
+        "password": "support",
+        "user_id": "support_demo",
+        "tenant_id": "tenant_demo",
+        "role": "support",
+    },
+    "admin": {
+        "password": "admin",
+        "user_id": "admin_demo",
+        "tenant_id": "tenant_demo",
+        "role": "admin",
+    },
+    "support_other": {
+        "password": "support",
+        "user_id": "support_other",
+        "tenant_id": "tenant_other",
+        "role": "support",
+    },
+}
+
+
+@dataclass(frozen=True)
+class CurrentUser:
+    sub: str
+    user_id: str
+    tenant_id: str
+    role: str
+
+
+bearer_scheme = HTTPBearer(auto_error=False) 
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def get_jwt_secret() -> str:
+    return os.getenv("JWT_SECRET", "demo-jwt-secret")
+
+
+def get_jwt_expire_minutes() -> int:
+    return int(os.getenv("JWT_EXPIRE_MINUTES", "60"))
+
+
+def get_demo_users() -> dict[str, dict[str, str]]:
+    raw_users = os.getenv("AUTH_DEMO_USERS_JSON")
+    if not raw_users:
+        return DEFAULT_DEMO_USERS
+    return json.loads(raw_users)
+
+
+def create_access_token(user: CurrentUser) -> str:
+    now = int(time.time())
+    payload = {
+        "sub": user.sub,
+        "user_id": user.user_id,
+        "tenant_id": user.tenant_id,
+        "role": user.role,
+        "exp": now + get_jwt_expire_minutes() * 60,
+    }
+    header = {"alg": "HS256", "typ": "JWT"}
+    signing_input = ".".join(
+        [
+            _b64encode(json.dumps(header, separators=(",", ":")).encode("utf-8")),
+            _b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8")),
+        ]
+    )
+    signature = hmac.new(
+        get_jwt_secret().encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{signing_input}.{_b64encode(signature)}"
+
+
+def decode_access_token(token: str) -> CurrentUser:
+    try:
+        header_b64, payload_b64, signature_b64 = token.split(".")
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+    signing_input = f"{header_b64}.{payload_b64}"
+    expected_signature = hmac.new(
+        get_jwt_secret().encode("utf-8"),
+        signing_input.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+
+    try:
+        if not hmac.compare_digest(_b64decode(signature_b64), expected_signature):
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+        payload: dict[str, Any] = json.loads(_b64decode(payload_b64))
+        if int(payload.get("exp", 0)) < int(time.time()):
+            raise HTTPException(status_code=401, detail="Token expired")
+
+        return CurrentUser(
+            sub=str(payload["sub"]),
+            user_id=str(payload["user_id"]),
+            tenant_id=str(payload["tenant_id"]),
+            role=str(payload["role"]),
+        )
+    except HTTPException:
+        raise
+    except (binascii.Error, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+
+def authenticate_demo_user(username: str, password: str) -> CurrentUser | None:
+    user = get_demo_users().get(username)
+    if not user or user.get("password") != password:
+        return None
+    return CurrentUser(
+        sub=username,
+        user_id=user["user_id"],
+        tenant_id=user["tenant_id"],
+        role=user["role"],
+    )
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> CurrentUser:
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+    return decode_access_token(credentials.credentials)
+
+
+def require_roles(*roles: str):
+    def dependency(user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
+        if user.role not in roles:
+            raise HTTPException(status_code=403, detail="Insufficient role")
+        return user
+
+    return dependency

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field as PydanticField
 from typing import Optional
 from contextlib import asynccontextmanager
@@ -18,11 +18,13 @@ import logging
 from experiments.rag_local.query_chroma import search_chroma
 from experiments.rag_local.query_rag_chroma import ask_rag
 
+from routers.auth import router as auth_router
 from routers.rag import router as rag_router
 from routers.tickets import router as tickets_router
 from routers.agent_ticket import router as agent_ticket_router
 from routers.agent_ops import router as agent_ops_router
 from routers.documents import router as documents_router
+from auth import CurrentUser, get_current_user
 
 from models.ticket import Ticket  # noqa: F401
 from models.agent_ops import AgentRun, ApprovalRequest, ToolCall  # noqa: F401
@@ -85,6 +87,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Enterprise Support AI Copilot API", lifespan= lifespan) # 把 lifespan 传给 FastAPI 实例，应用启动时自动调用 create_db_and_tables() 来创建数据库表格。
 
+app.include_router(auth_router)
 app.include_router(rag_router)  
 app.include_router(tickets_router)
 app.include_router(agent_ticket_router)
@@ -192,7 +195,7 @@ def about():
 
 
 @app.post("/echo")
-def echo(request: EchoRequest):
+def echo(request: EchoRequest, _user: CurrentUser = Depends(get_current_user)):
     return {
         "you_said": request.message,
         "repeat": request.repeat,
@@ -201,7 +204,7 @@ def echo(request: EchoRequest):
 
 
 @app.post("/chat")
-def chat(request: ChatRequest):
+def chat(request: ChatRequest, _user: CurrentUser = Depends(get_current_user)):
     fake_response = f"这是一个模拟 AI 回复：我收到了你的消息「{request.message}」"
 
     return {
@@ -210,7 +213,7 @@ def chat(request: ChatRequest):
     }
 
 @app.get("/todos", response_model=list[TodoResponse])
-def list_todos():
+def list_todos(_user: CurrentUser = Depends(get_current_user)):
     with Session(engine) as session:
         statement = select(Todo)
         todos = session.exec(statement).all()
@@ -218,7 +221,7 @@ def list_todos():
 
 
 @app.post("/todos", response_model=TodoResponse, status_code=201)
-def create_todo(todo: TodoCreate):
+def create_todo(todo: TodoCreate, _user: CurrentUser = Depends(get_current_user)):
     logger.info("Creating todo: %s", todo.title)
     
     db_todo = Todo(
@@ -235,7 +238,7 @@ def create_todo(todo: TodoCreate):
 
 
 @app.get("/todos/{todo_id}", response_model=TodoResponse)
-def get_todo(todo_id: int):
+def get_todo(todo_id: int, _user: CurrentUser = Depends(get_current_user)):
     with Session(engine) as session:
         todo = session.get(Todo, todo_id)   # session.get() 方法根据主键（这里是 id）查询数据库中的 Todo 记录
 
@@ -246,7 +249,11 @@ def get_todo(todo_id: int):
 
 
 @app.patch("/todos/{todo_id}", response_model=TodoResponse)
-def update_todo(todo_id: int, update: TodoUpdate):
+def update_todo(
+    todo_id: int,
+    update: TodoUpdate,
+    _user: CurrentUser = Depends(get_current_user),
+):
     with Session(engine) as session:
         todo = session.get(Todo, todo_id)   
 
@@ -270,7 +277,7 @@ def update_todo(todo_id: int, update: TodoUpdate):
 
 
 @app.delete("/todos/{todo_id}", status_code=200)
-def delete_todo(todo_id: int):
+def delete_todo(todo_id: int, _user: CurrentUser = Depends(get_current_user)):
     logger.info("Deleting todo with ID: %d", todo_id)
     with Session(engine) as session:
         todo = session.get(Todo, todo_id)
@@ -285,7 +292,7 @@ def delete_todo(todo_id: int):
 
 # 用户输入的一段消息，发送给 AI 模型进行对话
 @app.post("/ai/chat")
-def ai_chat(request: ChatRequest):
+def ai_chat(request: ChatRequest, _user: CurrentUser = Depends(get_current_user)):
     logger.info("Calling LLM chat endpoint with model: %s", settings.dashscope_model)
 
     if not settings.dashscope_api_key:
@@ -326,7 +333,7 @@ def ai_chat(request: ChatRequest):
 
 # 从用户输入的自然语言中提取出任务信息，返回给用户 
 @app.post("/ai/extract-tasks", response_model=TaskExtractResponse)
-def extract_tasks(request: TaskExtractRequest):
+def extract_tasks(request: TaskExtractRequest, _user: CurrentUser = Depends(get_current_user)):
     return extract_tasks_from_text(request.text)
 
 def extract_tasks_from_text(text: str) -> TaskExtractResponse:
@@ -376,7 +383,7 @@ def extract_tasks_from_text(text: str) -> TaskExtractResponse:
         )
     
 @app.post("/ai/create-todos", response_model=AICreateTodosResponse, status_code=201)
-def ai_create_todos(request: TaskExtractRequest):
+def ai_create_todos(request: TaskExtractRequest, _user: CurrentUser = Depends(get_current_user)):
     logger.info("Creating todos from AI extraction")
 
     extracted = extract_tasks_from_text(request.text) 

--- a/routers/agent_ops.py
+++ b/routers/agent_ops.py
@@ -1,5 +1,5 @@
 from typing import Literal
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 
 from schemas.agent_ops import (
     AgentOpsMetricsSummaryResponse,
@@ -31,7 +31,7 @@ from services.agent_ops_service import (
     list_tool_calls_by_run as list_tool_calls_by_run_service,
     update_approval_request as update_approval_request_service,
 )
-from mock_context import MOCK_TENANT_ID, MOCK_USER_ID
+from auth import CurrentUser, require_roles
 
 router = APIRouter(prefix="/agent-ops", tags=["agent-ops"])
 
@@ -68,6 +68,7 @@ RetrievalEndpointQuery = Literal[
 RetrievalStatusQuery = Literal[
     "ok",
     "no_context",
+    "refused_low_relevance",
     "failed",
 ]
 
@@ -78,9 +79,10 @@ def list_agent_runs(
     agent_name: str | None = None,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[AgentRunResponse]:
     agent_runs = list_agent_runs_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         status=status,
         agent_name=agent_name,
         limit=limit,
@@ -101,9 +103,10 @@ def get_retrieval_no_context_query_metrics(
     endpoint: RetrievalEndpointQuery | None = None,
     category: str | None = None,
     limit: int = Query(default=10, ge=1, le=100),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[RetrievalNoContextQueryMetricResponse]:
     return get_retrieval_no_context_query_metrics_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         endpoint=endpoint,
         category=category,
         limit=limit,
@@ -118,9 +121,10 @@ def get_retrieval_failure_metrics(
     endpoint: RetrievalEndpointQuery | None = None,
     category: str | None = None,
     limit: int = Query(default=10, ge=1, le=100),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[RetrievalFailureMetricResponse]:
     return get_retrieval_failure_metrics_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         endpoint=endpoint,
         category=category,
         limit=limit,
@@ -128,10 +132,13 @@ def get_retrieval_failure_metrics(
 
 
 @router.get("/runs/{agent_run_id}", response_model=AgentRunResponse)
-def get_agent_run(agent_run_id: int) -> AgentRunResponse:
+def get_agent_run(
+    agent_run_id: int,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
+) -> AgentRunResponse:
     agent_run = get_agent_run_service(
         agent_run_id=agent_run_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return AgentRunResponse.model_validate(agent_run)
@@ -141,10 +148,13 @@ def get_agent_run(agent_run_id: int) -> AgentRunResponse:
     "/runs/{agent_run_id}/trace",
     response_model=AgentRunTraceResponse,
 )
-def get_agent_run_trace(agent_run_id: int) -> AgentRunTraceResponse:
+def get_agent_run_trace(
+    agent_run_id: int,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
+) -> AgentRunTraceResponse:
     agent_run, tool_calls, approval_requests = get_agent_run_trace_service(
         agent_run_id=agent_run_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return AgentRunTraceResponse(
@@ -168,9 +178,10 @@ def list_tool_calls(
     error_type: str | None = None,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[ToolCallResponse]:
     tool_calls = list_tool_calls_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         agent_run_id=agent_run_id,
         status=status,
         tool_name=tool_name,
@@ -194,10 +205,11 @@ def list_tool_calls_by_run(
     status: ToolCallStatusQuery | None = None,
     tool_name: str | None = None,
     error_type: str | None = None,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[ToolCallResponse]:
     tool_calls = list_tool_calls_by_run_service(
         agent_run_id=agent_run_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         status=status,
         tool_name=tool_name,
         error_type=error_type,
@@ -219,9 +231,10 @@ def list_approval_requests(
     approval_type: ApprovalTypeQuery | None = None,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[ApprovalRequestResponse]:
     approval_requests = list_approval_requests_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         agent_run_id=agent_run_id,
         status=status,
         approval_type=approval_type,
@@ -241,10 +254,11 @@ def list_approval_requests(
 )
 def list_approval_requests_by_run(
     agent_run_id: int,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[ApprovalRequestResponse]:
     approval_requests = list_approval_requests_by_run_service(
         agent_run_id=agent_run_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return [
@@ -263,9 +277,10 @@ def list_retrieval_logs(
     category: str | None = None,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[RetrievalLogResponse]:
     retrieval_logs = list_retrieval_logs_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         endpoint=endpoint,
         retrieval_status=retrieval_status,
         category=category,
@@ -283,9 +298,11 @@ def list_retrieval_logs(
     "/metrics/summary",
     response_model=AgentOpsMetricsSummaryResponse,
 )
-def get_agent_ops_metrics_summary() -> AgentOpsMetricsSummaryResponse:
+def get_agent_ops_metrics_summary(
+    user: CurrentUser = Depends(require_roles("support", "admin")),
+) -> AgentOpsMetricsSummaryResponse:
     return get_agent_ops_metrics_summary_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
 
@@ -296,9 +313,10 @@ def get_agent_ops_metrics_summary() -> AgentOpsMetricsSummaryResponse:
 def get_retrieval_metrics_summary(
     endpoint: RetrievalEndpointQuery | None = None,
     category: str | None = None,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> RetrievalMetricsSummaryResponse:
     return get_retrieval_metrics_summary_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         endpoint=endpoint,
         category=category,
     )
@@ -312,9 +330,10 @@ def get_retrieval_source_metrics(
     endpoint: RetrievalEndpointQuery | None = None,
     category: str | None = None,
     limit: int = Query(default=10, ge=1, le=100),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> list[RetrievalSourceMetricResponse]:
     return get_retrieval_source_metrics_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         endpoint=endpoint,
         category=category,
         limit=limit,
@@ -328,13 +347,14 @@ def get_retrieval_source_metrics(
 def reject_approval_request(
     approval_request_id: int,
     request: ApprovalDecisionRequest,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> ApprovalRequestResponse:
     approval_request = update_approval_request_service(
         approval_request_id=approval_request_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         approval_request_update=ApprovalRequestUpdate(
             status="rejected",
-            approved_by=MOCK_USER_ID,
+            approved_by=user.user_id,
             decision_reason=request.reason,
         ),
     )
@@ -349,13 +369,14 @@ def reject_approval_request(
 def cancel_approval_request(
     approval_request_id: int,
     request: ApprovalDecisionRequest,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> ApprovalRequestResponse:
     approval_request = update_approval_request_service(
         approval_request_id=approval_request_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         approval_request_update=ApprovalRequestUpdate(
             status="cancelled",
-            approved_by=MOCK_USER_ID,
+            approved_by=user.user_id,
             decision_reason=request.reason,
         ),
     )

--- a/routers/agent_ticket.py
+++ b/routers/agent_ticket.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from schemas.agent_ticket import (
     TicketAgentConfirmRequest,
@@ -12,7 +12,7 @@ from services.ticket_agent_service import (
     confirm_ticket as confirm_ticket_service,
     preview_ticket as preview_ticket_service,
 )
-from mock_context import MOCK_TENANT_ID, MOCK_USER_ID
+from auth import CurrentUser, get_current_user
 
 
 router = APIRouter(
@@ -25,19 +25,21 @@ router = APIRouter(
 @router.post("/preview", response_model=TicketAgentPreviewResponse)
 def preview_ticket(
     request: TicketAgentPreviewRequest,
+    user: CurrentUser = Depends(get_current_user),
 ) -> TicketAgentPreviewResponse:
     return preview_ticket_service(
         request=request,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
 
 @router.post("/confirm", response_model=TicketAgentConfirmResponse, status_code=201)
 def confirm_ticket(
     request: TicketAgentConfirmRequest,
+    user: CurrentUser = Depends(get_current_user),
 ) -> TicketAgentConfirmResponse:
     return confirm_ticket_service(
         request=request,
-        tenant_id=MOCK_TENANT_ID,
-        created_by=MOCK_USER_ID,
+        tenant_id=user.tenant_id,
+        created_by=user.user_id,
     )

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from auth import CurrentUser, authenticate_demo_user, create_access_token, get_current_user
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class TokenRequest(BaseModel):
+    username: str = Field(..., min_length=1)
+    password: str = Field(..., min_length=1)
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class MeResponse(BaseModel):
+    sub: str
+    user_id: str
+    tenant_id: str
+    role: str
+
+
+@router.post("/token", response_model=TokenResponse)
+def create_token(request: TokenRequest) -> TokenResponse:
+    user = authenticate_demo_user(request.username, request.password)
+    if user is None:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    return TokenResponse(access_token=create_access_token(user))
+
+
+@router.get("/me", response_model=MeResponse)
+def read_me(user: CurrentUser = Depends(get_current_user)) -> MeResponse:
+    return MeResponse(
+        sub=user.sub,
+        user_id=user.user_id,
+        tenant_id=user.tenant_id,
+        role=user.role,
+    )

--- a/routers/documents.py
+++ b/routers/documents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from fastapi import APIRouter, File, Form, Query, UploadFile
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile
 
 from schemas.document import (
     DocumentCategory,
@@ -20,7 +20,7 @@ from services.document_service import (
     index_document as index_document_service,
     list_documents as list_documents_service,
 )
-from mock_context import MOCK_TENANT_ID, MOCK_USER_ID
+from auth import CurrentUser, require_roles
 
 
 router = APIRouter(
@@ -38,14 +38,15 @@ def get_document_storage_root() -> Path:
 async def upload_document(
     file: UploadFile = File(...),
     category: DocumentCategory = Form("other"),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> DocumentResponse:
     content = await file.read()
 
     document = create_document_from_bytes(
         filename=file.filename or "",
         content=content,
-        tenant_id=MOCK_TENANT_ID,
-        uploaded_by=MOCK_USER_ID,
+        tenant_id=user.tenant_id,
+        uploaded_by=user.user_id,
         category=category,
         storage_root=get_document_storage_root(),
     )
@@ -59,9 +60,10 @@ def list_documents(
     status: DocumentStatus | None = None,
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
+    user: CurrentUser = Depends(require_roles("support", "admin")),
 ) -> DocumentListResponse:
     documents, total = list_documents_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         category=category,
         status=status,
         limit=limit,
@@ -80,10 +82,13 @@ def list_documents(
 
 
 @router.post("/{document_id}/index", response_model=DocumentIndexResponse)
-def index_document(document_id: str) -> DocumentIndexResponse:
+def index_document(
+    document_id: str,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
+) -> DocumentIndexResponse:
     document = index_document_service(
         document_id=document_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return DocumentIndexResponse(
@@ -94,20 +99,26 @@ def index_document(document_id: str) -> DocumentIndexResponse:
 
 
 @router.get("/{document_id}", response_model=DocumentResponse)
-def get_document(document_id: str) -> DocumentResponse:
+def get_document(
+    document_id: str,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
+) -> DocumentResponse:
     document = get_document_service(
         document_id=document_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return DocumentResponse.model_validate(document)
 
 
 @router.delete("/{document_id}", response_model=DocumentDeleteResponse)
-def delete_document(document_id: str) -> DocumentDeleteResponse:
+def delete_document(
+    document_id: str,
+    user: CurrentUser = Depends(require_roles("support", "admin")),
+) -> DocumentDeleteResponse:
     document, deleted_embeddings = delete_document_service(
         document_id=document_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return DocumentDeleteResponse(

--- a/routers/rag.py
+++ b/routers/rag.py
@@ -1,6 +1,6 @@
 import json
 import time
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 
 
@@ -15,7 +15,7 @@ from schemas.rag import (
 from schemas.agent_ops import RetrievalLogCreate
 from services.agent_ops_service import create_retrieval_log as create_retrieval_log_service
 from services.rag_service import answer_question, search_documents
-from mock_context import MOCK_TENANT_ID
+from auth import CurrentUser, get_current_user
 
 
 # 创建一个 APIRouter 实例，设置前缀为 "/rag"，
@@ -46,7 +46,10 @@ def safe_create_retrieval_log(
 
 
 @router.post("/search", response_model=RagSearchResponse)
-def rag_search(request: RagSearchRequest):
+def rag_search(
+    request: RagSearchRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
     """根据用户的查询语句，搜索相关的文档片段"""
     started_at = time.perf_counter()
 
@@ -54,7 +57,7 @@ def rag_search(request: RagSearchRequest):
         results = search_documents(
             query=request.query,
             top_k=request.top_k,
-            tenant_id=MOCK_TENANT_ID,
+            tenant_id=user.tenant_id,
             category=request.category,
         )
     except Exception as exc:
@@ -62,7 +65,8 @@ def rag_search(request: RagSearchRequest):
 
         safe_create_retrieval_log(
             RetrievalLogCreate(
-                tenant_id=MOCK_TENANT_ID,
+                tenant_id=user.tenant_id,
+                user_id=user.user_id,
                 endpoint="search",
                 query_text=request.query,
                 top_k=request.top_k,
@@ -121,7 +125,8 @@ def rag_search(request: RagSearchRequest):
 
     safe_create_retrieval_log(
         RetrievalLogCreate(
-            tenant_id=MOCK_TENANT_ID,
+            tenant_id=user.tenant_id,
+            user_id=user.user_id,
             endpoint="search",
             query_text=request.query,
             top_k=request.top_k,
@@ -158,7 +163,10 @@ def rag_search(request: RagSearchRequest):
 
 
 @router.post("/ask", response_model=RagAskResponse)
-def rag_ask(request: RagAskRequest):
+def rag_ask(
+    request: RagAskRequest,
+    user: CurrentUser = Depends(get_current_user),
+):
     started_at = time.perf_counter()
 
     try:
@@ -166,7 +174,7 @@ def rag_ask(request: RagAskRequest):
             question=request.question,
             top_k=request.top_k,
             max_distance=request.max_distance,
-            tenant_id=MOCK_TENANT_ID,
+            tenant_id=user.tenant_id,
             category=request.category,
         )
     except Exception as exc:
@@ -174,7 +182,8 @@ def rag_ask(request: RagAskRequest):
 
         safe_create_retrieval_log(
             RetrievalLogCreate(
-                tenant_id=MOCK_TENANT_ID,
+                tenant_id=user.tenant_id,
+                user_id=user.user_id,
                 endpoint="ask",
                 query_text=request.question,
                 top_k=request.top_k,
@@ -233,7 +242,8 @@ def rag_ask(request: RagAskRequest):
 
     safe_create_retrieval_log(
         RetrievalLogCreate(
-            tenant_id=MOCK_TENANT_ID,
+            tenant_id=user.tenant_id,
+            user_id=user.user_id,
             endpoint="ask",
             query_text=request.question,
             top_k=request.top_k,

--- a/routers/tickets.py
+++ b/routers/tickets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from schemas.ticket import (
     TicketCategory,
@@ -15,7 +15,7 @@ from services.ticket_service import (
     list_tickets as list_tickets_service,
     update_ticket as update_ticket_service,
 )
-from mock_context import MOCK_TENANT_ID, MOCK_USER_ID
+from auth import CurrentUser, get_current_user
 
 
 router = APIRouter(
@@ -26,11 +26,14 @@ router = APIRouter(
 
 
 @router.post("", response_model=TicketResponse, status_code=201)
-def create_ticket(request: TicketCreate) -> TicketResponse:
+def create_ticket(
+    request: TicketCreate,
+    user: CurrentUser = Depends(get_current_user),
+) -> TicketResponse:
     ticket = create_ticket_service(
         ticket_create=request,
-        tenant_id=MOCK_TENANT_ID,
-        created_by=MOCK_USER_ID,
+        tenant_id=user.tenant_id,
+        created_by=user.user_id,
     )
 
     return TicketResponse.model_validate(ticket)
@@ -40,9 +43,10 @@ def create_ticket(request: TicketCreate) -> TicketResponse:
 def list_tickets(
     status: TicketStatus | None = None,
     category: TicketCategory | None = None,
+    user: CurrentUser = Depends(get_current_user),
 ) -> list[TicketResponse]:
     tickets = list_tickets_service(
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
         status=status,
         category=category,
     )
@@ -54,10 +58,13 @@ def list_tickets(
 
 
 @router.get("/{ticket_id}", response_model=TicketResponse)
-def get_ticket(ticket_id: int) -> TicketResponse:
+def get_ticket(
+    ticket_id: int,
+    user: CurrentUser = Depends(get_current_user),
+) -> TicketResponse:
     ticket = get_ticket_service(
         ticket_id=ticket_id,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return TicketResponse.model_validate(ticket)
@@ -67,11 +74,12 @@ def get_ticket(ticket_id: int) -> TicketResponse:
 def update_ticket(
     ticket_id: int,
     request: TicketUpdate,
+    user: CurrentUser = Depends(get_current_user),
 ) -> TicketResponse:
     ticket = update_ticket_service(
         ticket_id=ticket_id,
         ticket_update=request,
-        tenant_id=MOCK_TENANT_ID,
+        tenant_id=user.tenant_id,
     )
 
     return TicketResponse.model_validate(ticket)

--- a/scripts/smoke_agentops_flow.py
+++ b/scripts/smoke_agentops_flow.py
@@ -11,12 +11,15 @@ from urllib.request import Request, urlopen
 
 
 BASE_URL = os.getenv("API_BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+AUTH_USERNAME = os.getenv("AUTH_USERNAME", "support")
+AUTH_PASSWORD = os.getenv("AUTH_PASSWORD", "support")
 
 
 def request_json(
     method: str,
     path: str,
     payload: dict[str, Any] | None = None,
+    token: str | None = None,
 ) -> Any:
     url = f"{BASE_URL}{path}"
 
@@ -24,6 +27,8 @@ def request_json(
     headers = {
         "Accept": "application/json",
     }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
 
     if payload is not None:
         data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -71,6 +76,16 @@ def main() -> int:
     health = request_json("GET", "/health")
     print("health:", health)
 
+    token_response = request_json(
+        "POST",
+        "/auth/token",
+        {
+            "username": AUTH_USERNAME,
+            "password": AUTH_PASSWORD,
+        },
+    )
+    token = token_response["access_token"]
+
     print("[2/7] Creating ticket preview")
     preview = request_json(
         "POST",
@@ -79,6 +94,7 @@ def main() -> int:
             "message": "VPN 连不上，重启客户端也没用",
             "category": "it",
         },
+        token=token,
     )
 
     agent_run_id = preview["agent_run_id"]
@@ -106,6 +122,7 @@ def main() -> int:
     preview_tool_calls = request_json(
         "GET",
         f"/agent-ops/runs/{agent_run_id}/tool-calls",
+        token=token,
     )
 
     preview_tool_names = tool_names(preview_tool_calls)
@@ -131,6 +148,7 @@ def main() -> int:
     approval_requests = request_json(
         "GET",
         f"/agent-ops/runs/{agent_run_id}/approval-requests",
+        token=token,
     )
 
     matching_approval = next(
@@ -155,6 +173,7 @@ def main() -> int:
             "approval_request_id": approval_request_id,
             "draft": draft,
         },
+        token=token,
     )
 
     ticket = confirm["ticket"]
@@ -171,6 +190,7 @@ def main() -> int:
     full_tool_calls = request_json(
         "GET",
         f"/agent-ops/runs/{agent_run_id}/tool-calls",
+        token=token,
     )
 
     full_tool_names = tool_names(full_tool_calls)
@@ -197,6 +217,7 @@ def main() -> int:
     approval_requests_after_confirm = request_json(
         "GET",
         f"/agent-ops/runs/{agent_run_id}/approval-requests",
+        token=token,
     )
 
     matching_approval_after_confirm = next(
@@ -216,7 +237,7 @@ def main() -> int:
     )
 
     print("[7/7] Inspecting AgentOps metrics")
-    metrics = request_json("GET", "/agent-ops/metrics/summary")
+    metrics = request_json("GET", "/agent-ops/metrics/summary", token=token)
     print(json.dumps(metrics, ensure_ascii=False, indent=2))
 
     assert_condition(

--- a/scripts/smoke_document_backend_flow.py
+++ b/scripts/smoke_document_backend_flow.py
@@ -9,6 +9,8 @@ import httpx
 
 
 API_BASE_URL = os.getenv("API_BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+AUTH_USERNAME = os.getenv("AUTH_USERNAME", "support")
+AUTH_PASSWORD = os.getenv("AUTH_PASSWORD", "support")
 TIMEOUT_SECONDS = 120.0
 
 
@@ -99,6 +101,15 @@ Smoke run id: {run_id}
             require_status(response, 200, "GET /health")
             print("   OK")
 
+            response = client.post(
+                f"{API_BASE_URL}/auth/token",
+                json={"username": AUTH_USERNAME, "password": AUTH_PASSWORD},
+            )
+            require_status(response, 200, "POST /auth/token")
+            headers = {
+                "Authorization": f"Bearer {response.json()['access_token']}",
+            }
+
             print("2. Uploading document...")
             response = client.post(
                 f"{API_BASE_URL}/documents/upload",
@@ -110,6 +121,7 @@ Smoke run id: {run_id}
                         "text/markdown",
                     )
                 },
+                headers=headers,
             )
             require_status(response, 201, "POST /documents/upload")
             uploaded = response.json()
@@ -127,7 +139,10 @@ Smoke run id: {run_id}
             print(f"   OK document_id={document_id}")
 
             print("3. Indexing document...")
-            response = client.post(f"{API_BASE_URL}/documents/{document_id}/index")
+            response = client.post(
+                f"{API_BASE_URL}/documents/{document_id}/index",
+                headers=headers,
+            )
             require_status(response, 200, "POST /documents/{document_id}/index")
             indexed = response.json()
 
@@ -150,6 +165,7 @@ Smoke run id: {run_id}
                     "top_k": 5,
                     "category": "admin",
                 },
+                headers=headers,
             )
             require_status(response, 200, "POST /rag/search after index")
             search_data = response.json()
@@ -164,7 +180,10 @@ Smoke run id: {run_id}
             print("   OK uploaded document is retrievable")
 
             print("5. Deleting document...")
-            response = client.delete(f"{API_BASE_URL}/documents/{document_id}")
+            response = client.delete(
+                f"{API_BASE_URL}/documents/{document_id}",
+                headers=headers,
+            )
             require_status(response, 200, "DELETE /documents/{document_id}")
             deleted_data = response.json()
 
@@ -192,6 +211,7 @@ Smoke run id: {run_id}
                     "top_k": 5,
                     "category": "admin",
                 },
+                headers=headers,
             )
             require_status(response, 200, "POST /rag/search after delete")
             search_after_delete = response.json()
@@ -217,7 +237,10 @@ Smoke run id: {run_id}
                 print()
                 print("Cleanup: deleting uploaded document after failed smoke run...")
                 try:
-                    client.delete(f"{API_BASE_URL}/documents/{document_id}")
+                    client.delete(
+                        f"{API_BASE_URL}/documents/{document_id}",
+                        headers=headers,
+                    )
                 except Exception as exc:
                     print(f"Cleanup failed: {exc}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,24 @@
 from pathlib import Path
 import sys
 
+import pytest
+
 ROOT_DIR = Path(__file__).resolve().parents[1]  # 项目根目录
 
 if str(ROOT_DIR) not in sys.path:   # 确保项目根目录在 sys.path 中，这样测试文件才能正确导入项目中的模块
-    sys.path.insert(0, str(ROOT_DIR))       
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+@pytest.fixture(autouse=True)
+def default_auth_user():
+    from auth import CurrentUser, get_current_user
+    from main import app
+
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        sub="support",
+        user_id="user_demo",
+        tenant_id="tenant_demo",
+        role="support",
+    )
+    yield
+    app.dependency_overrides.pop(get_current_user, None)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,159 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from auth import get_current_user
+from main import app
+
+
+@pytest.fixture(autouse=True)
+def use_real_auth(default_auth_user):
+    app.dependency_overrides.pop(get_current_user, None)
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def auth_headers(client: TestClient, username: str, password: str) -> dict[str, str]:
+    response = client.post(
+        "/auth/token",
+        json={"username": username, "password": password},
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_demo_token_and_me_flow():
+    with TestClient(app) as client:
+        me_response = client.get(
+            "/auth/me",
+            headers=auth_headers(client, "support", "support"),
+        )
+
+    assert me_response.status_code == 200
+    assert me_response.json() == {
+        "sub": "support",
+        "user_id": "support_demo",
+        "tenant_id": "tenant_demo",
+        "role": "support",
+    }
+
+
+def test_demo_token_rejects_bad_password():
+    with TestClient(app) as client:
+        response = client.post(
+            "/auth/token",
+            json={"username": "support", "password": "wrong"},
+        )
+
+    assert response.status_code == 401
+
+
+def test_me_requires_bearer_token():
+    with TestClient(app) as client:
+        response = client.get("/auth/me")
+
+    assert response.status_code == 401
+
+
+def test_me_rejects_malformed_token():
+    with TestClient(app) as client:
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": "Bearer not-a-jwt"},
+        )
+
+    assert response.status_code == 401
+
+
+def test_me_rejects_tampered_token():
+    with TestClient(app) as client:
+        headers = auth_headers(client, "support", "support")
+        token = headers["Authorization"].removeprefix("Bearer ")
+        header, payload, signature = token.split(".")
+        tampered_payload = payload[:-1] + ("a" if payload[-1] != "a" else "b")
+        tampered = f"{header}.{tampered_payload}.{signature}"
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": f"Bearer {tampered}"},
+        )
+
+    assert response.status_code == 401
+
+
+def test_me_rejects_expired_token(monkeypatch):
+    monkeypatch.setenv("JWT_EXPIRE_MINUTES", "-1")
+    with TestClient(app) as client:
+        headers = auth_headers(client, "support", "support")
+        response = client.get("/auth/me", headers=headers)
+
+    assert response.status_code == 401
+
+
+def test_business_endpoint_requires_bearer_token():
+    with TestClient(app) as client:
+        response = client.get("/todos")
+
+    assert response.status_code == 401
+
+
+def test_employee_cannot_access_documents():
+    with TestClient(app) as client:
+        response = client.get(
+            "/documents",
+            headers=auth_headers(client, "employee", "employee"),
+        )
+
+    assert response.status_code == 403
+
+
+def test_support_can_access_documents():
+    with TestClient(app) as client:
+        response = client.get(
+            "/documents",
+            headers=auth_headers(client, "support", "support"),
+        )
+
+    assert response.status_code == 200
+
+
+def test_employee_cannot_access_agent_ops():
+    with TestClient(app) as client:
+        response = client.get(
+            "/agent-ops/metrics/summary",
+            headers=auth_headers(client, "employee", "employee"),
+        )
+
+    assert response.status_code == 403
+
+
+def test_support_can_access_agent_ops():
+    with TestClient(app) as client:
+        response = client.get(
+            "/agent-ops/metrics/summary",
+            headers=auth_headers(client, "support", "support"),
+        )
+
+    assert response.status_code == 200
+
+
+def test_ticket_is_hidden_from_other_tenant():
+    with TestClient(app) as client:
+        create_response = client.post(
+            "/tickets",
+            json={
+                "title": "Tenant scoped ticket",
+                "description": "Only tenant_demo should see this ticket.",
+                "category": "it",
+                "priority": "medium",
+            },
+            headers=auth_headers(client, "support", "support"),
+        )
+        assert create_response.status_code == 201
+        ticket_id = create_response.json()["id"]
+
+        other_tenant_response = client.get(
+            f"/tickets/{ticket_id}",
+            headers=auth_headers(client, "support_other", "support"),
+        )
+
+    assert other_tenant_response.status_code == 404


### PR DESCRIPTION
## Summary

This PR adds demo JWT authentication and routes tenant/user context from the token instead of mock constants.

## Included

- add `POST /auth/token`
- add `GET /auth/me`
- require bearer token for business APIs
- use token `tenant_id` / `user_id` in RAG, tickets, documents, ticket agent, and AgentOps routes
- restrict documents and AgentOps to `support` / `admin`
- add JWT, role access, and tenant isolation tests
- update smoke scripts to fetch and send bearer tokens

## Not Included

- no user table
- no password hashing
- no refresh token
- no production RBAC
- no CORS or rate limiting

## Verification

- JWT flow tested manually
- `tests/test_auth.py`: 12 passed
- focused API tests: 59 passed
- `compileall`: passed