### PR TITLE
Add Alembic migration baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ DATABASE_URL=sqlite:///data/todos.db
 SQL_ECHO=true
 
 EMBEDDING_MODEL=text-embedding-v4
+
+# Optional Docker-only proxy config. Use host.docker.internal, not 127.0.0.1.
+DOCKER_HTTP_PROXY=
+DOCKER_HTTPS_PROXY=
+DOCKER_NO_PROXY=localhost,127.0.0.1,::1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/README.md
+++ b/README.md
@@ -126,8 +126,11 @@ pip install -r requirements.txt
 启动服务：
 
 ```bash
+alembic upgrade head
 uvicorn main:app --reload
 ```
+
+如果旧的本地 SQLite 数据库还没有 Alembic 版本标记，可以删除 `data/todos.db` 后重新执行 `alembic upgrade head`。如果需要保留已有开发数据，请先备份数据库，再使用 `alembic stamp head` 标记当前 schema 版本。
 
 打开 Swagger：
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,14 @@ services:
       DATABASE_URL: sqlite:////app/data/todos.db
       DOCUMENT_STORAGE_ROOT: /app/storage/documents
       SQL_ECHO: "false"
+      HTTP_PROXY: ${DOCKER_HTTP_PROXY:-}
+      HTTPS_PROXY: ${DOCKER_HTTPS_PROXY:-}
+      NO_PROXY: ${DOCKER_NO_PROXY:-localhost,127.0.0.1,::1}
+      http_proxy: ${DOCKER_HTTP_PROXY:-}
+      https_proxy: ${DOCKER_HTTPS_PROXY:-}
+      no_proxy: ${DOCKER_NO_PROXY:-localhost,127.0.0.1,::1}
     volumes:
       - ./docker_data:/app/data
       - ./docker_storage:/app/storage
       - ./docker_chroma_db:/app/experiments/chroma_db
-    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    command: sh -c "alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port 8000"

--- a/main.py
+++ b/main.py
@@ -2,10 +2,9 @@ from datetime import datetime
 from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field as PydanticField
 from typing import Optional
-from contextlib import asynccontextmanager
-from sqlmodel import SQLModel, Field as SQLField, Session, create_engine, select
+from sqlmodel import Session, create_engine, select
 from pathlib import Path
-from database import engine, create_db_and_tables
+from database import engine
 import os
 
 from dotenv import load_dotenv
@@ -29,6 +28,7 @@ from auth import CurrentUser, get_current_user
 from models.ticket import Ticket  # noqa: F401
 from models.agent_ops import AgentRun, ApprovalRequest, ToolCall  # noqa: F401
 from models.document import Document, DocumentChunk  # noqa: F401
+from models.todo import Todo
 
 
 load_dotenv()   # 从 .env 文件加载环境变量
@@ -71,21 +71,7 @@ llm_client = OpenAI(
 )
 
 
-# 定义一个 SQLModel 模型，表示数据库中的 "todo" 表格结构
-class Todo(SQLModel, table=True):   #　table=True 表示这是一个数据库表格模型，表名默认为 "todo"
-    id: Optional[int] = SQLField(default=None, primary_key=True)    # id可以一开始为空，它是主键。
-    title: str
-    completed: bool = False
-    due_time: Optional[str] = None  # 任务的截止时间
-
-# 生命周期函数，在 FastAPI 启动时自动调用
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    create_db_and_tables()
-    yield   # yield 前面的代码：应用启动时执行。后面的代码：应用关闭时执行。
-
-
-app = FastAPI(title="Enterprise Support AI Copilot API", lifespan= lifespan) # 把 lifespan 传给 FastAPI 实例，应用启动时自动调用 create_db_and_tables() 来创建数据库表格。
+app = FastAPI(title="Enterprise Support AI Copilot API")
 
 app.include_router(auth_router)
 app.include_router(rag_router)  

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+from models.todo import Todo  # noqa: F401
+from models.agent_ops import AgentRun, ApprovalRequest, RetrievalLog, ToolCall  # noqa: F401
+from models.document import Document, DocumentChunk  # noqa: F401
+from models.ticket import Ticket  # noqa: F401
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+
+def get_database_url() -> str:
+    return os.getenv("DATABASE_URL", "sqlite:///data/todos.db")
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=get_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    section = config.get_section(config.config_ini_section, {})
+    section["sqlalchemy.url"] = get_database_url()
+    connectable = engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/20260705_0001_initial_schema.py
+++ b/migrations/versions/20260705_0001_initial_schema.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+revision = "20260705_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_runs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("user_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("agent_name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("input_message", sqlmodel.sql.sqltypes.AutoString(length=4000), nullable=False),
+        sa.Column("category", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("result_summary", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("retrieval_summary_json", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_agent_runs_agent_name", "agent_runs", ["agent_name"])
+    op.create_index("ix_agent_runs_category", "agent_runs", ["category"])
+    op.create_index("ix_agent_runs_status", "agent_runs", ["status"])
+    op.create_index("ix_agent_runs_tenant_id", "agent_runs", ["tenant_id"])
+    op.create_index("ix_agent_runs_user_id", "agent_runs", ["user_id"])
+
+    op.create_table(
+        "documents",
+        sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("uploaded_by", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("filename", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("file_type", sqlmodel.sql.sqltypes.AutoString(length=20), nullable=False),
+        sa.Column("category", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("source_path", sqlmodel.sql.sqltypes.AutoString(length=1000), nullable=False),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("checksum", sqlmodel.sql.sqltypes.AutoString(length=128), nullable=False),
+        sa.Column("chunk_count", sa.Integer(), nullable=False),
+        sa.Column("error_message", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_documents_category", "documents", ["category"])
+    op.create_index("ix_documents_status", "documents", ["status"])
+    op.create_index("ix_documents_tenant_id", "documents", ["tenant_id"])
+    op.create_index("ix_documents_uploaded_by", "documents", ["uploaded_by"])
+
+    op.create_table(
+        "ticket",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("created_by", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("title", sqlmodel.sql.sqltypes.AutoString(length=200), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=False),
+        sa.Column("category", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("priority", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_ticket_category", "ticket", ["category"])
+    op.create_index("ix_ticket_created_by", "ticket", ["created_by"])
+    op.create_index("ix_ticket_priority", "ticket", ["priority"])
+    op.create_index("ix_ticket_status", "ticket", ["status"])
+    op.create_index("ix_ticket_tenant_id", "ticket", ["tenant_id"])
+
+    op.create_table(
+        "todo",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("title", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("completed", sa.Boolean(), nullable=False),
+        sa.Column("due_time", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "approval_requests",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("agent_run_id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("approval_type", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("draft_json", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("approved_by", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("decision_reason", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("decided_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["agent_run_id"], ["agent_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_approval_requests_agent_run_id", "approval_requests", ["agent_run_id"])
+    op.create_index("ix_approval_requests_approval_type", "approval_requests", ["approval_type"])
+    op.create_index("ix_approval_requests_approved_by", "approval_requests", ["approved_by"])
+    op.create_index("ix_approval_requests_status", "approval_requests", ["status"])
+    op.create_index("ix_approval_requests_tenant_id", "approval_requests", ["tenant_id"])
+
+    op.create_table(
+        "document_chunks",
+        sa.Column("id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("document_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("chunk_index", sa.Integer(), nullable=False),
+        sa.Column("content", sqlmodel.sql.sqltypes.AutoString(length=8000), nullable=False),
+        sa.Column("category", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("metadata_json", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("embedding_id", sqlmodel.sql.sqltypes.AutoString(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_document_chunks_category", "document_chunks", ["category"])
+    op.create_index("ix_document_chunks_chunk_index", "document_chunks", ["chunk_index"])
+    op.create_index("ix_document_chunks_document_id", "document_chunks", ["document_id"])
+    op.create_index("ix_document_chunks_embedding_id", "document_chunks", ["embedding_id"])
+    op.create_index("ix_document_chunks_tenant_id", "document_chunks", ["tenant_id"])
+
+    op.create_table(
+        "retrieval_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("user_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("endpoint", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("query_text", sqlmodel.sql.sqltypes.AutoString(length=4000), nullable=False),
+        sa.Column("top_k", sa.Integer(), nullable=False),
+        sa.Column("category", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("retrieval_status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("total_hits", sa.Integer(), nullable=False),
+        sa.Column("top_distance", sa.Float(), nullable=True),
+        sa.Column("source_documents_json", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("scores_json", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("error_message", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_retrieval_logs_category", "retrieval_logs", ["category"])
+    op.create_index("ix_retrieval_logs_endpoint", "retrieval_logs", ["endpoint"])
+    op.create_index("ix_retrieval_logs_retrieval_status", "retrieval_logs", ["retrieval_status"])
+    op.create_index("ix_retrieval_logs_tenant_id", "retrieval_logs", ["tenant_id"])
+    op.create_index("ix_retrieval_logs_user_id", "retrieval_logs", ["user_id"])
+
+    op.create_table(
+        "tool_calls",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("agent_run_id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("tool_name", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("tool_input_json", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("tool_output_json", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("error_type", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=True),
+        sa.Column("error_message", sqlmodel.sql.sqltypes.AutoString(length=2000), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["agent_run_id"], ["agent_runs.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_tool_calls_agent_run_id", "tool_calls", ["agent_run_id"])
+    op.create_index("ix_tool_calls_error_type", "tool_calls", ["error_type"])
+    op.create_index("ix_tool_calls_status", "tool_calls", ["status"])
+    op.create_index("ix_tool_calls_tenant_id", "tool_calls", ["tenant_id"])
+    op.create_index("ix_tool_calls_tool_name", "tool_calls", ["tool_name"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tool_calls_tool_name", table_name="tool_calls")
+    op.drop_index("ix_tool_calls_tenant_id", table_name="tool_calls")
+    op.drop_index("ix_tool_calls_status", table_name="tool_calls")
+    op.drop_index("ix_tool_calls_error_type", table_name="tool_calls")
+    op.drop_index("ix_tool_calls_agent_run_id", table_name="tool_calls")
+    op.drop_table("tool_calls")
+
+    op.drop_index("ix_retrieval_logs_user_id", table_name="retrieval_logs")
+    op.drop_index("ix_retrieval_logs_tenant_id", table_name="retrieval_logs")
+    op.drop_index("ix_retrieval_logs_retrieval_status", table_name="retrieval_logs")
+    op.drop_index("ix_retrieval_logs_endpoint", table_name="retrieval_logs")
+    op.drop_index("ix_retrieval_logs_category", table_name="retrieval_logs")
+    op.drop_table("retrieval_logs")
+
+    op.drop_index("ix_document_chunks_tenant_id", table_name="document_chunks")
+    op.drop_index("ix_document_chunks_embedding_id", table_name="document_chunks")
+    op.drop_index("ix_document_chunks_document_id", table_name="document_chunks")
+    op.drop_index("ix_document_chunks_chunk_index", table_name="document_chunks")
+    op.drop_index("ix_document_chunks_category", table_name="document_chunks")
+    op.drop_table("document_chunks")
+
+    op.drop_index("ix_approval_requests_tenant_id", table_name="approval_requests")
+    op.drop_index("ix_approval_requests_status", table_name="approval_requests")
+    op.drop_index("ix_approval_requests_approved_by", table_name="approval_requests")
+    op.drop_index("ix_approval_requests_approval_type", table_name="approval_requests")
+    op.drop_index("ix_approval_requests_agent_run_id", table_name="approval_requests")
+    op.drop_table("approval_requests")
+
+    op.drop_table("todo")
+
+    op.drop_index("ix_ticket_tenant_id", table_name="ticket")
+    op.drop_index("ix_ticket_status", table_name="ticket")
+    op.drop_index("ix_ticket_priority", table_name="ticket")
+    op.drop_index("ix_ticket_created_by", table_name="ticket")
+    op.drop_index("ix_ticket_category", table_name="ticket")
+    op.drop_table("ticket")
+
+    op.drop_index("ix_documents_uploaded_by", table_name="documents")
+    op.drop_index("ix_documents_tenant_id", table_name="documents")
+    op.drop_index("ix_documents_status", table_name="documents")
+    op.drop_index("ix_documents_category", table_name="documents")
+    op.drop_table("documents")
+
+    op.drop_index("ix_agent_runs_user_id", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_tenant_id", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_status", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_category", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_agent_name", table_name="agent_runs")
+    op.drop_table("agent_runs")

--- a/models/todo.py
+++ b/models/todo.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Todo(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    completed: bool = False
+    due_time: Optional[str] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest
 httpx
 chromadb
 python-multipart
+alembic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,11 @@ if str(ROOT_DIR) not in sys.path:   # 确保项目根目录在 sys.path 中，�
 
 @pytest.fixture(autouse=True)
 def default_auth_user():
+    from database import create_db_and_tables
     from auth import CurrentUser, get_current_user
     from main import app
 
+    create_db_and_tables()
     app.dependency_overrides[get_current_user] = lambda: CurrentUser(
         sub="support",
         user_id="user_demo",


### PR DESCRIPTION
## Summary
- add Alembic baseline migration for current schema
- remove startup-time create_all dependency from app runtime
- run migrations before local/Docker app startup
- move legacy Todo model into models/todo.py
- add Docker-only proxy env hooks for local network troubleshooting

## Verification
- focused tests passed
- alembic upgrade/downgrade roundtrip passed
- local smoke scripts passed
- Docker /health passed

## Note
Docker model smoke may still require local Clash/DashScope proxy rule adjustment; application startup and health check are valid.