### PR TITLE
Add Ruff lint checks to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           python -m compileall -q .
 
+      - name: Run Ruff
+        run: |
+          ruff check .
+
       - name: Run focused tests
         run: |
           pytest \

--- a/experiments/chroma_search.py
+++ b/experiments/chroma_search.py
@@ -1,5 +1,3 @@
-import os
-import json
 from typing import Any
 
 import chromadb

--- a/experiments/chunk_level_rag.py
+++ b/experiments/chunk_level_rag.py
@@ -7,7 +7,6 @@ from dotenv import load_dotenv
 from openai import OpenAI
 
 import re
-from typing import Any
 
 load_dotenv()
 

--- a/experiments/evals/eval_chroma_retrieval.py
+++ b/experiments/evals/eval_chroma_retrieval.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
 
 from experiments.rag_local.query_chroma import ChromaSearchResult, search_chroma
-from experiments.evals.eval_core import load_eval_cases
 from experiments.evals import eval_core
 
 def result_to_preview(result: ChromaSearchResult) -> dict:

--- a/main.py
+++ b/main.py
@@ -2,8 +2,7 @@ from datetime import datetime
 from fastapi import Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field as PydanticField
 from typing import Optional
-from sqlmodel import Session, create_engine, select
-from pathlib import Path
+from sqlmodel import Session, select
 from database import engine
 import os
 
@@ -14,8 +13,6 @@ import json
 
 import logging
 
-from experiments.rag_local.query_chroma import search_chroma
-from experiments.rag_local.query_rag_chroma import ask_rag
 
 from routers.auth import router as auth_router
 from routers.rag import router as rag_router

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.ruff]
+target-version = "py311"
+extend-exclude = [
+    "data",
+    "docker_data",
+    "docker_storage",
+    "docker_chroma_db",
+    "storage",
+]

--- a/rag_runtime/query_rag_chroma.py
+++ b/rag_runtime/query_rag_chroma.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from dotenv import load_dotenv
 from openai import OpenAI

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ httpx==0.28.1
 chromadb==1.5.9
 python-multipart==0.0.32
 alembic==1.18.5
+ruff==0.15.21

--- a/services/agent_ops_service.py
+++ b/services/agent_ops_service.py
@@ -463,9 +463,6 @@ def list_retrieval_logs(
         retrieval_logs = session.exec(statement).all()
         return list(retrieval_logs)
 
- 
-def count_status(items, status: str) -> int:
-    return sum(1 for item in items if item.status == status)
 
 def count_status(
     items,

--- a/tests/test_agent_ops_service.py
+++ b/tests/test_agent_ops_service.py
@@ -4,7 +4,6 @@ import pytest
 from fastapi import HTTPException
 from sqlmodel import SQLModel, create_engine
 
-from models.agent_ops import AgentRun, ApprovalRequest, ToolCall
 from schemas.agent_ops import (
     AgentRunCreate,
     AgentRunUpdate,


### PR DESCRIPTION
## Summary

- pin Ruff 0.15.21
- add minimal Python 3.11 Ruff configuration
- add `ruff check .` to GitHub Actions
- remove unused imports and one duplicate function definition
- keep API behavior and business logic unchanged

## Verification

- `ruff check .` passed
- `python -m compileall -q .` passed
- focused tests: 110 passed