### PR TITLE
feat(eval): add R4 C1 hybrid rerank experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,9 @@ tmp_manual_docs/
 # Large local E1 rerank artifacts; compact manifests/metrics/evidence stay versioned.
 experiments/evals/reports/e1_rerank/*_checkpoint.jsonl
 experiments/evals/reports/e1_rerank/*_results.jsonl
+
+# Large/local R4 C1 artifacts; compact manifests/metrics/evidence stay versioned.
+experiments/evals/reports/r4_c1_hybrid_rerank/train_fused_snapshot.jsonl
+experiments/evals/reports/r4_c1_hybrid_rerank/train_checkpoint.jsonl
+experiments/evals/reports/r4_c1_hybrid_rerank/train_results.jsonl
+experiments/evals/reports/r4_c1_hybrid_rerank/train_inflight*.json

--- a/docs/superpowers/plans/2026-08-27-r4-c1-hybrid-rerank.md
+++ b/docs/superpowers/plans/2026-08-27-r4-c1-hybrid-rerank.md
@@ -733,8 +733,8 @@ Gate:
 
 ```python
 success = (
-    metrics["mrr@10"] >= 0.577206
-    and metrics["recall@20"] >= 0.810556
+    metrics["mrr@10"] >= 0.5772063492063492
+    and metrics["recall@20"] >= 0.8111111111111111
 )
 ```
 
@@ -929,9 +929,9 @@ Primary decision:
 
 ```text
 PASS C1:
-MRR@10 >= 0.577206
+MRR@10 >= 0.5772063492063492
 AND
-Recall@20 >= 0.810556
+Recall@20 >= 0.8111111111111111
 
 otherwise:
 C1 does not satisfy the pre-registered success gate.

--- a/docs/superpowers/plans/2026-08-27-r4-c1-hybrid-rerank.md
+++ b/docs/superpowers/plans/2026-08-27-r4-c1-hybrid-rerank.md
@@ -1,0 +1,1018 @@
+﻿# R4 C1 Hybrid + Rerank Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a zero-cost frozen Hybrid Dense+BM25 chunk snapshot for 450 TechQA TRAIN queries, then evaluate that exact snapshot with the frozen E1 qwen3-rerank contract under explicit paid-run safety controls.
+
+**Architecture:** C1 has a strict zero-cost / paid boundary. The zero-cost phase reconstructs the frozen TechQA chunk universe, takes the current frozen E0 Dense Top-100 chunk IDs, retrieves BM25 Top-100 chunks, fuses both rankings with equal-weight chunk-ID RRF(k=60), and persists all 450 fused Top-100 candidate pools as one immutable snapshot. The paid phase only reads and validates that snapshot, calls the unchanged E1 reranker, checkpoints each completed query, and computes the pre-registered C1 gate.
+
+**Tech Stack:** Python 3.11, pytest, Ruff, datasets 5.0.1, bm25s 0.3.10, ranx 0.3.21, OpenAI-compatible DashScope client, qwen3-rerank.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md`
+
+## Global Constraints
+
+- Work only on branch `feat/r4-c1-hybrid-rerank`.
+- Strict TDD, but only three behavior-level C1 contract tests.
+- Do not add field-by-field tests.
+- TRAIN only: exactly 450 answerable TechQA queries.
+- DEV must not enter any C1 code path.
+- Dense input is the current frozen E0 TRAIN Top-100 chunk ranking.
+- BM25 input is chunk-level Top-100 using the already frozen R4 chunk-BM25 configuration.
+- Each Dense and BM25 source ranking must contain exactly 100 unique chunk IDs.
+- Cross-source duplicates are preserved as two independent RRF contributions.
+- Fusion is equal-weight chunk-ID RRF with `rrf_k=60`.
+- Fusion output is exactly 100 unique chunks.
+- No per-document cap.
+- No adaptive BM25 depth.
+- No source weighting.
+- No query routing.
+- No RRF tuning.
+- Reranker model remains `qwen3-rerank`.
+- Reranker instruction remains exactly the E1 instruction.
+- Reranker input remains exactly 100 chunks.
+- Reranker query normalization remains `rstrip`.
+- Singapore provider deployment remains unchanged from E1.
+- SDK automatic retry must be disabled with `max_retries=0`.
+- Provider-token stop threshold is `13_500_000`.
+- Monetary safety envelope is USD `1.50`.
+- Completed checkpoint queries must never be sent again.
+- An unresolved inflight/uncertain query must not be automatically replayed.
+- No provider call is allowed during implementation, tests, snapshot preparation, or preflight.
+- The real paid run requires explicit human approval after zero-cost acceptance.
+- Do not rerun E1 solely to recreate missing paired diagnostics.
+- Do not use broad staging such as `git add .`.
+
+## Existing Components to Reuse
+
+Reuse without re-testing their internals:
+
+- `experiments/evals/ir/rrf.py`
+  - `fuse_rrf(rankings, rrf_k=60, top_k=100)`
+- `experiments/evals/retrievers/bm25_techqa_chunks.py`
+  - `TechQAChunk`
+  - `build_techqa_chunks`
+  - `TechQAChunkBM25Retriever`
+- `experiments/evals/rerankers/qwen3_reranker.py`
+  - `RerankCandidate`
+  - `rerank_candidates`
+  - `DEFAULT_RERANK_MODEL`
+  - `DEFAULT_RERANK_INSTRUCTION`
+- `experiments/evals/ir/ranx_adapter.py`
+  - document-collapse and retrieval metric helpers
+- `experiments/evals/eval_techqa_chunk_bm25.py`
+  - frozen TechQA / splitter / chunk-count provenance constants where appropriate
+- `experiments/evals/reports/e1_rerank/train_metrics.json`
+  - frozen E1 aggregate baseline
+
+## File Structure
+
+Create:
+
+- `experiments/evals/eval_techqa_hybrid_rerank.py`
+  - all C1 experiment-specific snapshot preparation, paid orchestration,
+    checkpoint safety, metrics, CLI and manifests.
+- `tests/test_eval_techqa_hybrid_rerank.py`
+  - exactly three C1 contract test functions.
+
+Modify:
+
+- `experiments/evals/rerankers/qwen3_reranker.py`
+  - set SDK `max_retries=0`.
+- `docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md`
+  - clarify that missing full E1 per-query evidence must not trigger a paid E1 rerun.
+- `experiments/evals/reports/cost_ledger.md`
+  - only after the real C1 paid run completes.
+
+C1 local/experimental output directory:
+
+`experiments/evals/reports/r4_c1_hybrid_rerank/`
+
+Expected artifacts:
+
+Zero-cost:
+- `train_fused_snapshot.jsonl`
+- `train_snapshot_manifest.json`
+- `train_preflight.json`
+
+Paid:
+- `train_checkpoint.jsonl`
+- `train_inflight.json` only while a request is unresolved
+- `train_results.jsonl`
+- `train_manifest.json`
+- `train_metrics.json`
+- `comparison.md`
+
+Large candidate-heavy snapshot/checkpoint/result files do not need to be
+committed when their SHA256 and provenance are persisted in compact
+versioned evidence.
+
+---
+
+### Task 1: Freeze the 450-query Hybrid candidate snapshot
+
+**Files:**
+- Create: `experiments/evals/eval_techqa_hybrid_rerank.py`
+- Create: `tests/test_eval_techqa_hybrid_rerank.py`
+
+**Interfaces:**
+
+Produces:
+
+```python
+@dataclass(frozen=True)
+class HybridCandidate:
+    chunk_id: str
+    document_id: str
+    content: str
+
+@dataclass(frozen=True)
+class HybridSnapshotRecord:
+    question_id: str
+    question: str
+    relevant_document_ids: tuple[str, ...]
+    dense_chunk_ids: tuple[str, ...]
+    bm25_chunk_ids: tuple[str, ...]
+    fused_candidates: tuple[HybridCandidate, ...]
+
+def build_hybrid_snapshot_record(
+    record: Mapping[str, Any],
+    *,
+    chunks_by_id: Mapping[str, TechQAChunk],
+    bm25_searcher: Callable[..., list[TechQAChunk]],
+) -> HybridSnapshotRecord
+
+def prepare_frozen_snapshot(...) -> dict[str, Any]
+```
+
+#### Contract 1 — candidate construction
+
+- [ ] **Step 1: Write one RED covering the entire candidate contract**
+
+Create `tests/test_eval_techqa_hybrid_rerank.py`.
+
+The first test is:
+
+```python
+def test_candidate_snapshot_contract_preserves_cross_source_rrf_credit():
+    module = _load_module()
+
+    dense_ids = [f"d{i}" for i in range(99)]
+    bm25_ids = [f"b{i}" for i in range(99)]
+
+    # shared is rank 50 in both sources.
+    dense_ids.insert(49, "shared")
+    bm25_ids.insert(49, "shared")
+
+    all_ids = set(dense_ids) | set(bm25_ids)
+
+    chunks_by_id = {
+        chunk_id: module.TechQAChunk(
+            chunk_id=chunk_id,
+            document_id=f"doc-{chunk_id}",
+            chunk_index=0,
+            content=f"content for {chunk_id}",
+        )
+        for chunk_id in all_ids
+    }
+
+    record = {
+        "question_id": "TRAIN_Q1",
+        "question": "shared technical query",
+        "relevant_document_ids": ["doc-shared"],
+        "raw_chunk_ids": dense_ids,
+    }
+
+    bm25_chunks = [chunks_by_id[chunk_id] for chunk_id in bm25_ids]
+
+    result = module.build_hybrid_snapshot_record(
+        record,
+        chunks_by_id=chunks_by_id,
+        bm25_searcher=lambda query, top_k: bm25_chunks[:top_k],
+    )
+
+    assert len(result.dense_chunk_ids) == 100
+    assert len(set(result.dense_chunk_ids)) == 100
+    assert len(result.bm25_chunk_ids) == 100
+    assert len(set(result.bm25_chunk_ids)) == 100
+
+    fused_ids = [candidate.chunk_id for candidate in result.fused_candidates]
+
+    assert len(fused_ids) == 100
+    assert len(set(fused_ids)) == 100
+
+    # rank 50 + rank 50 receives two RRF contributions and therefore
+    # outranks chunks seen in only one source at rank 1.
+    assert fused_ids[0] == "shared"
+```
+
+The module loader may fail with a clear message if the new evaluator module
+does not yet exist.
+
+- [ ] **Step 2: Run the RED and stop**
+
+Run:
+
+```powershell
+pytest tests/test_eval_techqa_hybrid_rerank.py::test_candidate_snapshot_contract_preserves_cross_source_rrf_credit -v
+```
+
+Expected:
+
+FAIL because `build_hybrid_snapshot_record` does not exist.
+
+Do not add more candidate-construction unit tests.
+
+- [ ] **Step 3: Implement only the candidate contract**
+
+Implement in `experiments/evals/eval_techqa_hybrid_rerank.py`:
+
+```python
+EXPECTED_TRAIN_COUNT = 450
+CANDIDATE_K = 100
+RRF_K = 60
+
+def _require_unique_exact(
+    values: Sequence[str],
+    *,
+    expected: int,
+    label: str,
+) -> tuple[str, ...]:
+    normalized = tuple(str(value) for value in values)
+
+    if len(normalized) != expected:
+        raise RuntimeError(
+            f"{label} must contain exactly {expected} chunks: "
+            f"actual={len(normalized)}"
+        )
+
+    if len(set(normalized)) != expected:
+        raise RuntimeError(f"{label} contains duplicate chunk_id values")
+
+    return normalized
+
+
+def build_hybrid_snapshot_record(
+    record,
+    *,
+    chunks_by_id,
+    bm25_searcher,
+):
+    question_id = str(record["question_id"])
+
+    if not question_id.startswith("TRAIN_"):
+        raise RuntimeError("C1 requires TRAIN-only input")
+
+    dense_chunk_ids = _require_unique_exact(
+        record["raw_chunk_ids"],
+        expected=CANDIDATE_K,
+        label="Dense candidate ranking",
+    )
+
+    bm25_chunks = bm25_searcher(
+        str(record["question"]).rstrip(),
+        top_k=CANDIDATE_K,
+    )
+
+    bm25_chunk_ids = _require_unique_exact(
+        [chunk.chunk_id for chunk in bm25_chunks],
+        expected=CANDIDATE_K,
+        label="BM25 candidate ranking",
+    )
+
+    fused_chunk_ids = tuple(
+        fuse_rrf(
+            [dense_chunk_ids, bm25_chunk_ids],
+            rrf_k=RRF_K,
+            top_k=CANDIDATE_K,
+        )
+    )
+
+    fused_chunk_ids = _require_unique_exact(
+        fused_chunk_ids,
+        expected=CANDIDATE_K,
+        label="Hybrid fused ranking",
+    )
+
+    missing = [
+        chunk_id
+        for chunk_id in fused_chunk_ids
+        if chunk_id not in chunks_by_id
+    ]
+    if missing:
+        raise RuntimeError(
+            "fused chunk(s) missing from frozen chunk universe: "
+            + ", ".join(missing[:5])
+        )
+
+    return HybridSnapshotRecord(
+        question_id=question_id,
+        question=str(record["question"]),
+        relevant_document_ids=tuple(
+            str(value)
+            for value in record["relevant_document_ids"]
+        ),
+        dense_chunk_ids=dense_chunk_ids,
+        bm25_chunk_ids=bm25_chunk_ids,
+        fused_candidates=tuple(
+            HybridCandidate(
+                chunk_id=chunks_by_id[chunk_id].chunk_id,
+                document_id=chunks_by_id[chunk_id].document_id,
+                content=chunks_by_id[chunk_id].content,
+            )
+            for chunk_id in fused_chunk_ids
+        ),
+    )
+```
+
+Use the existing `fuse_rrf`; do not write another RRF implementation.
+
+- [ ] **Step 4: Run GREEN**
+
+```powershell
+pytest tests/test_eval_techqa_hybrid_rerank.py::test_candidate_snapshot_contract_preserves_cross_source_rrf_credit -v
+ruff check experiments/evals/eval_techqa_hybrid_rerank.py tests/test_eval_techqa_hybrid_rerank.py
+```
+
+Expected: PASS and Ruff clean.
+
+- [ ] **Step 5: Add zero-cost snapshot materialization**
+
+In the same module implement:
+
+```text
+load current E0 TRAIN JSONL
+→ require exactly 450 TRAIN rows
+→ load frozen TechQA corpus from manifest revision
+→ build 28,481 TechQA documents
+→ build deterministic 172,614 chunks
+→ build one chunks_by_id map
+→ build one TechQAChunkBM25Retriever
+→ build HybridSnapshotRecord for all 450 rows
+→ write train_fused_snapshot.jsonl
+→ SHA256 snapshot
+→ write train_snapshot_manifest.json
+→ write train_preflight.json
+```
+
+The manifest must record at minimum:
+
+```json
+{
+  "run": "r4_c1_hybrid_rerank",
+  "split": "train",
+  "query_count": 450,
+  "dense_candidate_k": 100,
+  "bm25_candidate_k": 100,
+  "rrf_k": 60,
+  "fused_candidate_k": 100,
+  "provider_calls": 0,
+  "dev_artifact_opened": false,
+  "snapshot_sha256": "...",
+  "reranker_model": "qwen3-rerank",
+  "token_stop_threshold": 13500000,
+  "monetary_safety_envelope_usd": 1.50
+}
+```
+
+Also record:
+- current E0 input SHA
+- historical E1 E0 source SHA
+- TechQA frozen revision
+- corpus SHA
+- splitter blob SHA
+- chunk count
+- bm25s version/config
+- project SHA
+
+Do not call any provider from the `prepare` path.
+
+CLI:
+
+```powershell
+python -m experiments.evals.eval_techqa_hybrid_rerank prepare
+```
+
+- [ ] **Step 6: Commit Task 1**
+
+Stage exact files only:
+
+```powershell
+git add experiments/evals/eval_techqa_hybrid_rerank.py tests/test_eval_techqa_hybrid_rerank.py
+git commit -m "feat(eval): build frozen R4 C1 hybrid snapshot"
+```
+
+---
+
+### Task 2: Rerank one frozen Hybrid query without changing E1 behavior
+
+**Files:**
+- Modify: `experiments/evals/eval_techqa_hybrid_rerank.py`
+- Modify: `tests/test_eval_techqa_hybrid_rerank.py`
+
+**Interfaces:**
+
+Produces:
+
+```python
+@dataclass(frozen=True)
+class HybridRerankResult:
+    question_id: str
+    relevant_document_ids: tuple[str, ...]
+    fused_chunk_ids: tuple[str, ...]
+    reranked_chunk_ids: tuple[str, ...]
+    reranked_document_ids: tuple[str, ...]
+    document_ranking: tuple[str, ...]
+    rerank_latency_ms: float
+    request_id: str | None
+    total_tokens: int | None
+
+def rerank_snapshot_record(
+    record: HybridSnapshotRecord,
+    *,
+    reranker: Reranker = rerank_candidates,
+    clock: Clock = time.perf_counter,
+) -> HybridRerankResult
+```
+
+#### Contract 2 — one-query orchestration
+
+- [ ] **Step 1: Append exactly one new RED**
+
+```python
+def test_one_query_orchestration_preserves_frozen_candidates_and_provider_identity():
+    module = _load_module()
+
+    candidates = tuple(
+        module.HybridCandidate(
+            chunk_id=f"c{i}",
+            document_id=("shared-doc" if i < 2 else f"doc{i}"),
+            content=f"content {i}",
+        )
+        for i in range(100)
+    )
+
+    record = module.HybridSnapshotRecord(
+        question_id="TRAIN_Q1",
+        question="technical query",
+        relevant_document_ids=("shared-doc",),
+        dense_chunk_ids=tuple(f"d{i}" for i in range(100)),
+        bm25_chunk_ids=tuple(f"b{i}" for i in range(100)),
+        fused_candidates=candidates,
+    )
+
+    class FakeResult:
+        def __init__(self):
+            self.results = tuple(
+                module.RerankedCandidate(
+                    chunk_id=candidates[index].chunk_id,
+                    document_id=candidates[index].document_id,
+                    content=candidates[index].content,
+                    original_index=index,
+                    relevance_score=float(100 - index),
+                )
+                for index in reversed(range(100))
+            )
+            self.request_id = "req-c1"
+            self.total_tokens = 12345
+
+    seen = {}
+
+    def fake_reranker(query, rerank_candidates):
+        seen["query"] = query
+        seen["chunk_ids"] = [item.chunk_id for item in rerank_candidates]
+        return FakeResult()
+
+    result = module.rerank_snapshot_record(
+        record,
+        reranker=fake_reranker,
+        clock=iter([1.0, 1.25]).__next__,
+    )
+
+    assert seen["query"] == "technical query"
+    assert seen["chunk_ids"] == [f"c{i}" for i in range(100)]
+    assert len(result.reranked_chunk_ids) == 100
+    assert result.document_ranking[0] == "doc99"
+    assert len(result.document_ranking) == 99
+    assert result.request_id == "req-c1"
+    assert result.total_tokens == 12345
+    assert result.rerank_latency_ms == 250.0
+```
+
+- [ ] **Step 2: Run RED**
+
+```powershell
+pytest tests/test_eval_techqa_hybrid_rerank.py::test_one_query_orchestration_preserves_frozen_candidates_and_provider_identity -v
+```
+
+Expected: FAIL because `rerank_snapshot_record` is absent.
+
+- [ ] **Step 3: Implement minimal orchestration**
+
+Implementation must:
+
+```text
+validate TRAIN question_id
+validate exactly 100 fused candidates
+convert them to existing RerankCandidate
+call existing rerank_candidates-compatible callable
+retain complete provider permutation
+collapse document IDs by first occurrence
+record latency/request_id/total_tokens
+```
+
+Do not alter:
+- model
+- instruction
+- query normalization
+- candidate count
+- document-collapse rule.
+
+Use the existing reranker and ranx/document-collapse helpers instead of
+reimplementing provider parsing.
+
+- [ ] **Step 4: GREEN + Ruff**
+
+```powershell
+pytest tests/test_eval_techqa_hybrid_rerank.py::test_one_query_orchestration_preserves_frozen_candidates_and_provider_identity -v
+ruff check experiments/evals/eval_techqa_hybrid_rerank.py tests/test_eval_techqa_hybrid_rerank.py
+```
+
+- [ ] **Step 5: Commit Task 2**
+
+```powershell
+git add experiments/evals/eval_techqa_hybrid_rerank.py tests/test_eval_techqa_hybrid_rerank.py
+git commit -m "feat(eval): add R4 C1 hybrid rerank orchestration"
+```
+
+---
+
+### Task 3: Add the paid-run safety boundary and resumable runner
+
+**Files:**
+- Modify: `experiments/evals/eval_techqa_hybrid_rerank.py`
+- Modify: `experiments/evals/rerankers/qwen3_reranker.py`
+- Modify: `tests/test_eval_techqa_hybrid_rerank.py`
+
+**Interfaces:**
+
+Produces:
+
+```python
+TOKEN_STOP_THRESHOLD = 13_500_000
+
+def validate_paid_snapshot(...) -> list[HybridSnapshotRecord]
+
+def run_resumable_paid_eval(
+    records,
+    *,
+    evaluator,
+    checkpoint_path,
+    inflight_path,
+    token_stop_threshold=TOKEN_STOP_THRESHOLD,
+) -> HybridRerankSummary
+```
+
+#### Contract 3 — paid-run safety
+
+- [ ] **Step 1: Append one final C1 contract test**
+
+Use one test function containing a small set of sequential safety scenarios.
+Do not split these into separate tests.
+
+The test must verify:
+
+```text
+1. completed checkpoint qid -> provider evaluator not called
+2. wrong snapshot SHA -> failure before provider evaluator
+3. fused candidate count != 100 -> failure before provider evaluator
+4. cumulative checkpoint tokens >= 13.5M -> next provider call not sent
+5. evaluator/provider exception -> run stops and inflight marker remains
+6. unresolved inflight qid not in checkpoint -> resume refuses automatic replay
+7. DEV_* qid -> failure before provider use
+8. get_rerank_client constructs OpenAI with max_retries=0
+```
+
+For the SDK assertion monkeypatch `OpenAI` and inspect constructor kwargs;
+do not contact the network.
+
+- [ ] **Step 2: Run RED**
+
+```powershell
+pytest tests/test_eval_techqa_hybrid_rerank.py::test_paid_runner_safety_contract -v
+```
+
+Expected: FAIL on missing paid-run safety behavior.
+
+- [ ] **Step 3: Disable SDK retries**
+
+Modify:
+
+`experiments/evals/rerankers/qwen3_reranker.py`
+
+from:
+
+```python
+return OpenAI(api_key=api_key, base_url=base_url)
+```
+
+to:
+
+```python
+return OpenAI(
+    api_key=api_key,
+    base_url=base_url,
+    max_retries=0,
+)
+```
+
+No other reranker behavior changes.
+
+- [ ] **Step 4: Implement snapshot verification before provider use**
+
+Paid startup order must be:
+
+```text
+load snapshot manifest
+→ SHA256 actual snapshot
+→ compare expected SHA
+→ load snapshot
+→ require 450 unique TRAIN question IDs
+→ require exactly 100 unique fused chunks per record
+→ inspect inflight marker
+→ load completed checkpoint
+→ only then allow evaluator/provider use
+```
+
+Any failure before the final step must result in zero provider calls.
+
+- [ ] **Step 5: Implement minimal inflight safety**
+
+Before each provider request:
+
+```json
+{"question_id": "TRAIN_Q123"}
+```
+
+is written to `train_inflight.json`.
+
+After a successful provider result:
+
+```text
+append durable checkpoint result
+→ then remove inflight marker
+```
+
+Resume behavior:
+
+```text
+no inflight marker
+    -> normal resume
+
+inflight qid already present in completed checkpoint
+    -> stale marker may be cleared safely
+
+inflight qid NOT present in completed checkpoint
+    -> uncertain provider outcome
+    -> stop
+    -> do not automatically replay
+```
+
+Do not create a general state-machine framework.
+
+- [ ] **Step 6: Implement token stop semantics**
+
+At startup:
+
+```python
+provider_total_tokens = sum(
+    result.total_tokens or 0
+    for result in completed_results
+)
+```
+
+Before every new request:
+
+```python
+if provider_total_tokens >= token_stop_threshold:
+    break
+```
+
+After a successful response is checkpointed:
+
+```python
+provider_total_tokens += result.total_tokens or 0
+```
+
+Then evaluate the threshold before the next request.
+
+Do not claim that 13.5M can never be exceeded by the last already-issued
+request.
+
+- [ ] **Step 7: Implement metrics and C1 gate**
+
+Final TRAIN metrics:
+
+- Recall@5
+- Recall@20
+- MRR@10
+- rerank latency p50
+- rerank latency p95
+- provider total tokens
+- completed query count
+
+Frozen E1 baseline:
+
+```text
+Recall@5  = 0.6911111111111111
+Recall@20 = 0.8155555555555556
+MRR@10    = 0.5672063492063492
+```
+
+Gate:
+
+```python
+success = (
+    metrics["mrr@10"] >= 0.577206
+    and metrics["recall@20"] >= 0.810556
+)
+```
+
+Write both observed metrics and gate outcome.
+
+Do not retrofit thresholds after seeing results.
+
+Do not rerun E1 for per-query comparison.
+
+- [ ] **Step 8: Add explicit CLI separation**
+
+CLI must expose only:
+
+```powershell
+python -m experiments.evals.eval_techqa_hybrid_rerank prepare
+python -m experiments.evals.eval_techqa_hybrid_rerank paid
+```
+
+`prepare`:
+- may load corpus
+- may build BM25
+- may RRF
+- must never construct/call the provider client.
+
+`paid`:
+- must never rerun Dense
+- must never rebuild BM25
+- must never rerun RRF
+- consumes only the frozen snapshot.
+
+There is no `--split dev` option.
+
+- [ ] **Step 9: GREEN the three C1 contracts**
+
+```powershell
+pytest tests/test_eval_techqa_hybrid_rerank.py -v
+```
+
+Expected:
+
+```text
+3 passed
+```
+
+Do not add more C1 tests unless a real defect discovered later requires one
+regression test.
+
+- [ ] **Step 10: Run relevant existing regression tests**
+
+```powershell
+pytest `
+  tests/test_rrf.py `
+  tests/test_bm25_techqa_chunks.py `
+  tests/test_qwen3_reranker.py `
+  tests/test_eval_techqa_rerank.py `
+  tests/test_eval_techqa_hybrid_rerank.py `
+  -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 11: Run full verification**
+
+```powershell
+pytest -q
+ruff check .
+```
+
+Expected:
+- zero failures
+- Ruff clean.
+
+- [ ] **Step 12: Commit Task 3**
+
+```powershell
+git add `
+  experiments/evals/eval_techqa_hybrid_rerank.py `
+  experiments/evals/rerankers/qwen3_reranker.py `
+  tests/test_eval_techqa_hybrid_rerank.py
+
+git commit -m "feat(eval): enforce R4 C1 paid-run safety"
+```
+
+---
+
+### Task 4: Zero-provider-call real snapshot acceptance
+
+This task does not add another unit test.
+
+- [ ] **Step 1: Run snapshot preparation**
+
+```powershell
+python -m experiments.evals.eval_techqa_hybrid_rerank prepare
+```
+
+This command must make zero provider calls.
+
+Expected high-level evidence:
+
+```text
+split=TRAIN
+query_count=450
+documents=28481
+chunks=172614
+dense_candidate_k=100
+bm25_candidate_k=100
+rrf_k=60
+fused_candidate_k=100
+provider_calls=0
+dev_artifact_opened=false
+```
+
+- [ ] **Step 2: Verify frozen artifacts**
+
+Check:
+
+```powershell
+Get-Content experiments/evals/reports/r4_c1_hybrid_rerank/train_preflight.json
+Get-Content experiments/evals/reports/r4_c1_hybrid_rerank/train_snapshot_manifest.json
+```
+
+Verify:
+- 450 queries
+- every qid starts `TRAIN_`
+- snapshot SHA exists
+- actual snapshot SHA equals manifest SHA
+- all Dense rankings are 100 unique chunks
+- all BM25 rankings are 100 unique chunks
+- all fused rankings are 100 unique chunks
+- RRF k=60
+- provider_calls=0
+- DEV unopened
+- qwen3-rerank identity matches E1
+- token threshold=13.5M
+- monetary envelope=$1.50.
+
+- [ ] **Step 3: Re-run verification after the real snapshot exists**
+
+```powershell
+pytest -q
+ruff check .
+git status --short
+```
+
+No provider call.
+
+- [ ] **Step 4: STOP**
+
+Do NOT run:
+
+```powershell
+python -m experiments.evals.eval_techqa_hybrid_rerank paid
+```
+
+until the human explicitly reviews the zero-cost preflight and approves the
+paid run.
+
+This is the mandatory paid boundary.
+
+---
+
+### Task 5: Execute the paid C1 run after explicit approval
+
+This task begins only after explicit human approval.
+
+- [ ] **Step 1: Run the frozen paid experiment**
+
+```powershell
+python -m experiments.evals.eval_techqa_hybrid_rerank paid
+```
+
+Expected behavior:
+- reads frozen snapshot only
+- validates SHA before provider use
+- resumes completed qids
+- no automatic SDK retry
+- no automatic uncertain-qid replay
+- stops on provider error
+- stops before the next request once cumulative returned tokens reach 13.5M.
+
+- [ ] **Step 2: Inspect final evidence**
+
+Read:
+
+```powershell
+Get-Content experiments/evals/reports/r4_c1_hybrid_rerank/train_metrics.json
+Get-Content experiments/evals/reports/r4_c1_hybrid_rerank/train_manifest.json
+Get-Content experiments/evals/reports/r4_c1_hybrid_rerank/comparison.md
+```
+
+Primary decision:
+
+```text
+PASS C1:
+MRR@10 >= 0.577206
+AND
+Recall@20 >= 0.810556
+
+otherwise:
+C1 does not satisfy the pre-registered success gate.
+```
+
+A negative result is valid evidence and must not be patched post-hoc by
+changing RRF, BM25 depth, source weighting, rerank depth or thresholds.
+
+- [ ] **Step 3: Update the cost ledger with actual evidence**
+
+Modify:
+
+`experiments/evals/reports/cost_ledger.md`
+
+Record:
+- actual returned provider tokens
+- actual estimated/known spend
+- whether the run completed all 450 queries
+- C1 gate decision
+- question answered.
+
+- [ ] **Step 4: Final verification and exact staging**
+
+```powershell
+pytest -q
+ruff check .
+git diff --check
+git status --short
+```
+
+Stage only compact evidence and source/test changes intended for the PR.
+Do not blindly commit large local snapshot/checkpoint files.
+
+---
+
+## Execution Order Summary
+
+```text
+Task 1
+candidate snapshot contract
+        |
+        v
+Task 2
+one-query rerank contract
+        |
+        v
+Task 3
+paid-run safety contract
+        |
+        v
+full pytest + Ruff
+        |
+        v
+Task 4
+REAL 450-query zero-cost snapshot
+        |
+        v
+snapshot SHA + preflight review
+        |
+        v
+HUMAN PAID APPROVAL
+        |
+        v
+Task 5
+qwen3-rerank paid C1
+        |
+        v
+frozen success gate
+```
+
+## Testing Budget
+
+C1-specific test count is intentionally capped at three behavior-level
+contract tests before the real experiment:
+
+1. candidate construction
+2. one-query orchestration
+3. paid-run safety
+
+No fourth test is added merely to increase coverage.
+
+A new test beyond those three is allowed only when:
+- an actual defect is observed during implementation/acceptance, and
+- the test is a regression test for that concrete defect.

--- a/docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md
+++ b/docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md
@@ -196,13 +196,19 @@ This corresponds to:
 
 Recall@5 is reported but is not a hard success condition.
 
-Paired diagnostic evidence is also reported:
+Paired diagnostic evidence is reported only if complete preserved E1
+per-query evidence is available for all 450 TRAIN queries.
 
-- MRR@10 improved / regressed / unchanged
-- Recall@5 fixed / regressed
-- Recall@20 fixed / regressed
+The repository does not preserve the complete historical E1 per-query
+rerank artifact. C1 must therefore NOT rerun E1 solely to recreate paired
+counts.
 
-These paired counts explain the result but do not redefine the gate.
+The authoritative C1 comparison is the frozen aggregate E1 baseline and
+the pre-registered success gate above.
+
+Any partial historical paired evidence may be reported only as
+supplementary evidence and must not be presented as a full-population
+450-query comparison.
 
 ## 8. Provenance boundary
 
@@ -234,7 +240,7 @@ Paid phase:
 - resumable checkpoint/results
 - run manifest
 - metrics
-- paired comparison against E1
+- aggregate comparison against the frozen E1 baseline; paired comparison only if complete preserved E1 per-query evidence exists
 - provider token usage
 - latency summary
 - final gate decision
@@ -321,3 +327,4 @@ C1 will not:
 
 Any such optimization belongs to C2 and is considered only after C1
 results are known.
+

--- a/docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md
+++ b/docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md
@@ -1,0 +1,323 @@
+﻿# R4 C1 Hybrid + Rerank Design
+
+Date: 2026-08-27
+Branch: `feat/r4-c1-hybrid-rerank`
+Status: Approved
+
+## 1. Goal
+
+C1 tests one controlled hypothesis:
+
+> Holding the reranker contract fixed, does replacing E1's Dense-only
+> Top-100 chunk candidate pool with a Hybrid Dense + BM25 candidate pool
+> improve the final TechQA TRAIN ranking?
+
+C1 is the controlled stage of a two-stage strategy:
+
+- C1: causal comparison against E1 with candidate construction as the main variable.
+- C2: optional optimization only if C1 provides positive evidence.
+
+No DEV data may be used in C1.
+
+## 2. Frozen E1 baseline
+
+TRAIN query count: 450.
+
+E1 metrics:
+
+- Recall@5: 0.691111
+- Recall@20: 0.815556
+- MRR@10: 0.567206
+
+E1 reranker contract:
+
+- model: `qwen3-rerank`
+- candidate budget: 100 chunks
+- instruction:
+  `Rank the candidate passages by relevance to resolving the technical support query.`
+- query normalization: `rstrip`
+- final document ranking:
+  first occurrence of `document_id` after chunk rerank
+
+C1 must preserve this reranker contract.
+
+## 3. Frozen candidate construction
+
+For each TRAIN query:
+
+```text
+Frozen Dense Top-100 unique chunks --+
+                                     +-- chunk-id RRF(k=60)
+Chunk BM25 Top-100 unique chunks -----+
+                    |
+                    v
+          fused Top-100 unique chunks
+                    |
+                    v
+               qwen3-rerank
+                    |
+                    v
+        first-occurrence doc collapse
+```
+
+Rules:
+
+1. Dense contributes exactly its frozen Top-100 chunk ranking.
+2. BM25 retrieves Top-100 chunks using the already frozen chunk-BM25
+   configuration from the R4 audit.
+3. Each source ranking must contain unique `chunk_id` values.
+4. Cross-source overlap must NOT be removed before RRF.
+5. RRF is equal-weight, `k=60`, aggregated by `chunk_id`.
+6. A chunk present in both Dense and BM25 receives both rank contributions.
+7. RRF output must contain exactly 100 unique chunks.
+8. No per-document cap, adaptive BM25 depth, source weighting, query routing,
+   or other candidate tuning is allowed in C1.
+
+## 4. Zero-cost frozen candidate snapshot
+
+Candidate construction is completed before any paid rerank call.
+
+All 450 TRAIN queries are materialized into a frozen Hybrid candidate
+snapshot.
+
+Each query record must contain at least:
+
+- `question_id`
+- question required by the reranker
+- `relevant_document_ids`
+- Dense Top-100 chunk IDs
+- BM25 Top-100 chunk IDs
+- fused Top-100 candidates
+- fused candidate `chunk_id`
+- fused candidate `document_id`
+- candidate content required by the reranker
+
+The snapshot must be complete for all 450 queries before paid execution.
+
+The snapshot is hashed with SHA256 and its identity is recorded in the
+C1 manifest.
+
+The paid runner consumes this frozen snapshot only. It must not rerun
+Dense retrieval, BM25 retrieval, or RRF during paid execution or resume.
+
+If the snapshot is missing or its SHA does not match the manifest,
+paid execution must fail before contacting the provider.
+
+A large candidate-heavy snapshot may remain a local experimental
+artifact if its SHA256 and provenance are persisted in the compact
+versioned manifest.
+
+## 5. Paid rerank contract
+
+Frozen paid configuration:
+
+- split: TRAIN only
+- queries: at most 450
+- model: `qwen3-rerank`
+- provider deployment: same Singapore deployment as E1
+- instruction: exactly the E1 instruction
+- rerank input: exactly 100 fused chunks per query
+- SDK automatic retry: disabled with `max_retries=0`
+- DEV: forbidden
+
+The paid runner is resumable.
+
+Completed query IDs already durably persisted in the checkpoint must
+never call the provider again.
+
+## 6. Paid-run safety
+
+### Provider-token stop threshold
+
+Normal stop threshold:
+
+`13,500,000 provider-reported tokens`
+
+Token usage is known only after a provider response is received.
+
+Execution order:
+
+```text
+provider request
+-> successful response
+-> persist completed result/checkpoint
+-> update cumulative provider tokens
+-> if cumulative tokens >= 13.5M:
+     stop before sending another request
+```
+
+The threshold may be exceeded by the final already-issued request.
+
+### Monetary safety envelope
+
+Absolute experiment budget envelope:
+
+`USD 1.50`
+
+The token threshold is the normal application stop control.
+The monetary envelope is the outer budget safety bound.
+
+### Provider errors and retries
+
+SDK automatic retries are disabled.
+
+Any provider error stops the run immediately.
+
+To avoid silently replaying a request whose provider-side outcome is
+unknown, the runner maintains only the minimum durable attempt state:
+
+- completed: durable checkpoint exists; automatically skip on resume
+- never started: eligible to call provider
+- inflight/uncertain: automatic retry is forbidden; stop for manual review
+
+This is a paid-run safety mechanism, not a general workflow/state-machine
+subsystem.
+
+## 7. Evaluation and success gate
+
+Primary metrics:
+
+- Recall@5
+- Recall@20
+- MRR@10
+
+Pre-registered C1 success gate:
+
+```text
+MRR@10 >= 0.577206
+AND
+Recall@20 >= 0.810556
+```
+
+This corresponds to:
+
+- MRR@10 absolute improvement of at least +0.010 over E1
+- Recall@20 regression no worse than -0.005 absolute
+
+Recall@5 is reported but is not a hard success condition.
+
+Paired diagnostic evidence is also reported:
+
+- MRR@10 improved / regressed / unchanged
+- Recall@5 fixed / regressed
+- Recall@20 fixed / regressed
+
+These paired counts explain the result but do not redefine the gate.
+
+## 8. Provenance boundary
+
+Historical E1 references an E0 TRAIN results SHA that is no longer
+recoverable byte-for-byte.
+
+The current recoverable E0 TRAIN artifact has already been independently
+verified against R3 for all 450 TRAIN queries at the query ID, gold
+document, and collapsed dense document-ranking level.
+
+C1 therefore records both the recoverable input identity and the
+historical provenance note.
+
+C1 must not claim that the historical E1 raw Top-100 chunk artifact has
+been proven byte-identical when that evidence is unavailable.
+
+This provenance limitation does not change the C1 execution contract.
+
+## 9. Required artifacts
+
+Zero-cost phase:
+
+- frozen Hybrid candidate snapshot
+- snapshot manifest with SHA256
+- preflight summary
+
+Paid phase:
+
+- resumable checkpoint/results
+- run manifest
+- metrics
+- paired comparison against E1
+- provider token usage
+- latency summary
+- final gate decision
+- cost-ledger update
+
+## 10. Testing scope
+
+C1 adds only three behavior-level contract scenarios.
+
+### Contract 1 - candidate construction
+
+Validate one complete Hybrid construction behavior:
+
+```text
+Dense + BM25
+-> source uniqueness
+-> RRF(k=60)
+-> shared chunks receive both contributions
+-> exactly 100 unique fused chunks
+```
+
+### Contract 2 - one-query orchestration
+
+Validate:
+
+```text
+frozen fused Top-100
+-> fake qwen3-rerank result
+-> complete reranked permutation
+-> document collapse
+-> result/token/request identity
+```
+
+### Contract 3 - paid-run safety
+
+Validate the paid execution boundary as one scenario family:
+
+- completed checkpoint queries are skipped
+- manifest/snapshot identity mismatch fails before provider use
+- candidate count != 100 fails before provider use
+- token stop threshold prevents the next request
+- provider error stops execution
+- inflight/uncertain query is not automatically replayed
+- DEV cannot enter the C1 paid path
+- rerank client disables SDK retries
+
+Existing lower-level RRF, BM25, reranker parsing, tie-breaking, tokenizer,
+and checkpoint tests are reused and are not duplicated.
+
+## 11. Acceptance sequence
+
+Before any real provider call:
+
+```text
+3 C1 contract tests
+-> relevant existing retrieval/rerank tests
+-> full pytest
+-> Ruff
+-> zero-provider-call build of all 450 fused candidate records
+-> freeze snapshot + SHA + manifest
+-> verify preflight contract
+-> explicit human approval
+-> paid TRAIN run
+```
+
+No paid provider call is allowed during implementation or zero-cost
+acceptance.
+
+## 12. Non-goals
+
+C1 will not:
+
+- tune BM25 depth
+- add adaptive retrieval
+- add per-document chunk caps
+- tune RRF k
+- weight Dense/BM25 differently
+- change reranker model/instruction
+- inspect DEV
+- optimize generation
+- add a general experiment workflow framework
+- add tests beyond the minimum contract coverage unless a real bug requires
+  a regression test
+
+Any such optimization belongs to C2 and is considered only after C1
+results are known.

--- a/docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md
+++ b/docs/superpowers/specs/2026-08-27-r4-c1-hybrid-rerank-design.md
@@ -150,7 +150,7 @@ The threshold may be exceeded by the final already-issued request.
 
 ### Monetary safety envelope
 
-Absolute experiment budget envelope:
+Approved monetary safety envelope:
 
 `USD 1.50`
 
@@ -184,9 +184,9 @@ Primary metrics:
 Pre-registered C1 success gate:
 
 ```text
-MRR@10 >= 0.577206
+MRR@10 >= 0.5772063492063492
 AND
-Recall@20 >= 0.810556
+Recall@20 >= 0.8111111111111111
 ```
 
 This corresponds to:

--- a/experiments/evals/eval_techqa_hybrid_rerank.py
+++ b/experiments/evals/eval_techqa_hybrid_rerank.py
@@ -1,0 +1,629 @@
+﻿from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from importlib.metadata import version
+from pathlib import Path
+from typing import Any
+
+from experiments.evals.adapters.techqa import build_techqa_documents
+from experiments.evals.eval_techqa_chunk_bm25 import (
+    EXPECTED_SPLITTER_BLOB_SHA,
+    EXPECTED_TECHQA_CHUNK_COUNT,
+)
+from experiments.evals.eval_techqa_rerank import (
+    load_frozen_e0_rerank_records,
+)
+from experiments.evals.ir.rrf import fuse_rrf
+from experiments.evals.rerankers.qwen3_reranker import (
+    DEFAULT_RERANK_INSTRUCTION,
+    DEFAULT_RERANK_MODEL,
+)
+from experiments.evals.retrievers.bm25_techqa_chunks import (
+    TechQAChunk,
+    TechQAChunkBM25Retriever,
+    build_techqa_chunks,
+)
+
+
+EXPECTED_TRAIN_COUNT = 450
+EXPECTED_DOCUMENT_COUNT = 28481
+CANDIDATE_K = 100
+RRF_K = 60
+TOKEN_STOP_THRESHOLD = 13_500_000
+MONETARY_SAFETY_ENVELOPE_USD = 1.50
+
+DEFAULT_E0_TRAIN_RESULTS_PATH = Path(
+    "experiments/evals/reports/e0_dense/train_results.jsonl"
+)
+DEFAULT_E1_TRAIN_MANIFEST_PATH = Path(
+    "experiments/evals/reports/e1_rerank/train_manifest.json"
+)
+DEFAULT_R4_AUDIT_MANIFEST_PATH = Path(
+    "experiments/evals/reports/r4_chunk_bm25_audit/train_manifest.json"
+)
+DEFAULT_TECHQA_MANIFEST_PATH = Path(
+    "experiments/evals/datasets/techqa/manifest.json"
+)
+DEFAULT_OUTPUT_DIR = Path(
+    "experiments/evals/reports/r4_c1_hybrid_rerank"
+)
+DEFAULT_SNAPSHOT_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_fused_snapshot.jsonl"
+)
+DEFAULT_SNAPSHOT_MANIFEST_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_snapshot_manifest.json"
+)
+DEFAULT_PREFLIGHT_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_preflight.json"
+)
+
+
+@dataclass(frozen=True)
+class HybridCandidate:
+    chunk_id: str
+    document_id: str
+    content: str
+
+
+@dataclass(frozen=True)
+class HybridSnapshotRecord:
+    question_id: str
+    question: str
+    relevant_document_ids: tuple[str, ...]
+    dense_chunk_ids: tuple[str, ...]
+    bm25_chunk_ids: tuple[str, ...]
+    fused_candidates: tuple[HybridCandidate, ...]
+
+
+def _require_unique_exact(
+    values: Sequence[str],
+    *,
+    expected: int,
+    label: str,
+) -> tuple[str, ...]:
+    normalized = tuple(str(value) for value in values)
+
+    if len(normalized) != expected:
+        raise RuntimeError(
+            f"{label} must contain exactly {expected} chunks: "
+            f"actual={len(normalized)}"
+        )
+
+    if len(set(normalized)) != expected:
+        raise RuntimeError(
+            f"{label} contains duplicate chunk_id values"
+        )
+
+    return normalized
+
+
+def build_hybrid_snapshot_record(
+    record: Mapping[str, Any],
+    *,
+    chunks_by_id: Mapping[str, TechQAChunk],
+    bm25_searcher: Callable[..., list[TechQAChunk]],
+) -> HybridSnapshotRecord:
+    question_id = str(record["question_id"])
+
+    if not question_id.startswith("TRAIN_"):
+        raise RuntimeError("C1 requires TRAIN-only input")
+
+    dense_chunk_ids = _require_unique_exact(
+        record["raw_chunk_ids"],
+        expected=CANDIDATE_K,
+        label="Dense candidate ranking",
+    )
+
+    bm25_chunks = bm25_searcher(
+        str(record["question"]).rstrip(),
+        top_k=CANDIDATE_K,
+    )
+
+    bm25_chunk_ids = _require_unique_exact(
+        [chunk.chunk_id for chunk in bm25_chunks],
+        expected=CANDIDATE_K,
+        label="BM25 candidate ranking",
+    )
+
+    fused_chunk_ids = tuple(
+        fuse_rrf(
+            [dense_chunk_ids, bm25_chunk_ids],
+            rrf_k=RRF_K,
+            top_k=CANDIDATE_K,
+        )
+    )
+
+    fused_chunk_ids = _require_unique_exact(
+        fused_chunk_ids,
+        expected=CANDIDATE_K,
+        label="Hybrid fused ranking",
+    )
+
+    missing = [
+        chunk_id
+        for chunk_id in fused_chunk_ids
+        if chunk_id not in chunks_by_id
+    ]
+    if missing:
+        raise RuntimeError(
+            "fused chunk(s) missing from frozen chunk universe: "
+            + ", ".join(missing[:5])
+        )
+
+    return HybridSnapshotRecord(
+        question_id=question_id,
+        question=str(record["question"]),
+        relevant_document_ids=tuple(
+            str(value)
+            for value in record["relevant_document_ids"]
+        ),
+        dense_chunk_ids=dense_chunk_ids,
+        bm25_chunk_ids=bm25_chunk_ids,
+        fused_candidates=tuple(
+            HybridCandidate(
+                chunk_id=chunks_by_id[chunk_id].chunk_id,
+                document_id=chunks_by_id[chunk_id].document_id,
+                content=chunks_by_id[chunk_id].content,
+            )
+            for chunk_id in fused_chunk_ids
+        ),
+    )
+
+
+def _sha256(path: str | Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _resolve_project_sha() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = completed.stdout.strip()
+
+    if not value:
+        raise RuntimeError("unable to resolve project SHA")
+
+    return value
+
+
+def _resolve_splitter_blob_sha() -> str:
+    completed = subprocess.run(
+        [
+            "git",
+            "hash-object",
+            "rag_runtime/text_splitter.py",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _write_json(
+    path: str | Path,
+    payload: Mapping[str, Any],
+) -> None:
+    Path(path).write_text(
+        json.dumps(
+            dict(payload),
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_snapshot(
+    records: Sequence[HybridSnapshotRecord],
+    path: str | Path,
+) -> None:
+    snapshot_path = Path(path)
+    snapshot_path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with snapshot_path.open(
+        "w",
+        encoding="utf-8",
+        newline="\n",
+    ) as file:
+        for record in records:
+            file.write(
+                json.dumps(
+                    asdict(record),
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+
+
+def prepare_frozen_snapshot(
+    *,
+    e0_results_path: str | Path = DEFAULT_E0_TRAIN_RESULTS_PATH,
+    dataset_manifest_path: str | Path = DEFAULT_TECHQA_MANIFEST_PATH,
+    e1_manifest_path: str | Path = DEFAULT_E1_TRAIN_MANIFEST_PATH,
+    audit_manifest_path: str | Path = DEFAULT_R4_AUDIT_MANIFEST_PATH,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, Any]:
+    e0_path = Path(e0_results_path)
+    dataset_path = Path(dataset_manifest_path)
+    e1_path = Path(e1_manifest_path)
+    audit_path = Path(audit_manifest_path)
+    output_path = Path(output_dir)
+
+    required_paths = (
+        e0_path,
+        dataset_path,
+        e1_path,
+        audit_path,
+    )
+    missing_paths = [
+        str(path)
+        for path in required_paths
+        if not path.exists()
+    ]
+    if missing_paths:
+        raise RuntimeError(
+            "required C1 input artifact(s) missing: "
+            + ", ".join(missing_paths)
+        )
+
+    print("[R4 C1] Loading frozen E0 TRAIN records...")
+
+    records = load_frozen_e0_rerank_records(
+        e0_path,
+        expected_count=EXPECTED_TRAIN_COUNT,
+    )
+
+    question_ids = [
+        str(record["question_id"])
+        for record in records
+    ]
+
+    if any(
+        not question_id.startswith("TRAIN_")
+        for question_id in question_ids
+    ):
+        raise RuntimeError(
+            "C1 snapshot preparation requires TRAIN-only input"
+        )
+
+    if len(set(question_ids)) != EXPECTED_TRAIN_COUNT:
+        raise RuntimeError(
+            "C1 requires exactly 450 unique TRAIN question IDs"
+        )
+
+    dataset_manifest = json.loads(
+        dataset_path.read_text(encoding="utf-8")
+    )
+    retrieval_dataset = dataset_manifest[
+        "retrieval_dataset"
+    ]
+
+    audit_manifest = json.loads(
+        audit_path.read_text(encoding="utf-8")
+    )
+    e1_manifest = json.loads(
+        e1_path.read_text(encoding="utf-8")
+    )
+
+    actual_e0_sha = _sha256(e0_path)
+    expected_current_e0_sha = str(
+        audit_manifest[
+            "input_e0_train_results_sha256"
+        ]
+    )
+    historical_e0_sha = str(
+        e1_manifest["identity"]["source_e0"][
+            "results_sha256"
+        ]
+    )
+
+    if actual_e0_sha != expected_current_e0_sha:
+        raise RuntimeError(
+            "current frozen E0 TRAIN artifact changed: "
+            f"expected={expected_current_e0_sha}, "
+            f"actual={actual_e0_sha}"
+        )
+
+    audit_historical_sha = str(
+        audit_manifest[
+            "historical_e0_train_results_sha256"
+        ]
+    )
+    if historical_e0_sha != audit_historical_sha:
+        raise RuntimeError(
+            "historical E0 provenance disagreement between "
+            "E1 and R4 audit manifests"
+        )
+
+    splitter_blob_sha = _resolve_splitter_blob_sha()
+    if splitter_blob_sha != EXPECTED_SPLITTER_BLOB_SHA:
+        raise RuntimeError(
+            "splitter blob mismatch: "
+            f"expected={EXPECTED_SPLITTER_BLOB_SHA}, "
+            f"actual={splitter_blob_sha}"
+        )
+
+    bm25_version = version("bm25s")
+    if bm25_version != "0.3.10":
+        raise RuntimeError(
+            "bm25s version mismatch: "
+            f"expected=0.3.10, actual={bm25_version}"
+        )
+
+    print("[R4 C1] Loading frozen TechQA corpus...")
+
+    from datasets import load_dataset
+
+    corpus_rows = load_dataset(
+        retrieval_dataset["repo"],
+        "corpus",
+        split="train",
+        revision=retrieval_dataset["revision"],
+    )
+
+    documents = build_techqa_documents(corpus_rows)
+
+    if len(documents) != EXPECTED_DOCUMENT_COUNT:
+        raise RuntimeError(
+            "TechQA document count mismatch: "
+            f"expected={EXPECTED_DOCUMENT_COUNT}, "
+            f"actual={len(documents)}"
+        )
+
+    print(
+        "[R4 C1] Building deterministic chunk universe: "
+        f"documents={len(documents)}"
+    )
+
+    chunks = build_techqa_chunks(documents)
+
+    if len(chunks) != EXPECTED_TECHQA_CHUNK_COUNT:
+        raise RuntimeError(
+            "TechQA chunk count mismatch: "
+            f"expected={EXPECTED_TECHQA_CHUNK_COUNT}, "
+            f"actual={len(chunks)}"
+        )
+
+    chunks_by_id = {
+        chunk.chunk_id: chunk
+        for chunk in chunks
+    }
+
+    if len(chunks_by_id) != EXPECTED_TECHQA_CHUNK_COUNT:
+        raise RuntimeError(
+            "TechQA chunk universe contains duplicate chunk IDs"
+        )
+
+    print(
+        "[R4 C1] Building chunk BM25 index: "
+        f"chunks={len(chunks)}"
+    )
+
+    bm25_retriever = TechQAChunkBM25Retriever(chunks)
+
+    print(
+        "[R4 C1] Building Hybrid fused candidates: "
+        f"queries={len(records)}"
+    )
+
+    snapshot_records = [
+        build_hybrid_snapshot_record(
+            record,
+            chunks_by_id=chunks_by_id,
+            bm25_searcher=bm25_retriever.search,
+        )
+        for record in records
+    ]
+
+    if len(snapshot_records) != EXPECTED_TRAIN_COUNT:
+        raise RuntimeError(
+            "C1 snapshot query count mismatch"
+        )
+
+    snapshot_path = (
+        output_path / DEFAULT_SNAPSHOT_PATH.name
+    )
+    snapshot_manifest_path = (
+        output_path
+        / DEFAULT_SNAPSHOT_MANIFEST_PATH.name
+    )
+    preflight_path = (
+        output_path / DEFAULT_PREFLIGHT_PATH.name
+    )
+
+    output_path.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    _write_snapshot(
+        snapshot_records,
+        snapshot_path,
+    )
+
+    snapshot_sha = _sha256(snapshot_path)
+
+    manifest: dict[str, Any] = {
+        "benchmark": "TechQA-RAG-Eval",
+        "run": "r4_c1_hybrid_rerank",
+        "split": "train",
+        "query_count": EXPECTED_TRAIN_COUNT,
+        "provider_calls": 0,
+        "dev_artifact_opened": False,
+        "candidate_construction": {
+            "dense_candidate_k": CANDIDATE_K,
+            "bm25_candidate_k": CANDIDATE_K,
+            "rrf_k": RRF_K,
+            "rrf_weights": "equal",
+            "rrf_unit": "chunk_id",
+            "fused_candidate_k": CANDIDATE_K,
+            "cross_source_overlap_rule": (
+                "retain both source rank contributions"
+            ),
+        },
+        "snapshot": {
+            "path": str(snapshot_path),
+            "sha256": snapshot_sha,
+            "format": "jsonl",
+        },
+        "reranker": {
+            "model": DEFAULT_RERANK_MODEL,
+            "instruction": DEFAULT_RERANK_INSTRUCTION,
+            "candidate_chunk_k": CANDIDATE_K,
+            "query_normalization": "rstrip",
+            "provider_region": "Singapore",
+        },
+        "paid_safety": {
+            "token_stop_threshold": (
+                TOKEN_STOP_THRESHOLD
+            ),
+            "monetary_safety_envelope_usd": (
+                MONETARY_SAFETY_ENVELOPE_USD
+            ),
+        },
+        "chunking": {
+            "strategy": "paragraph_aware_character",
+            "chunk_size": 800,
+            "chunk_overlap": 120,
+            "min_chunk_size": 150,
+            "splitter_blob_sha": splitter_blob_sha,
+            "observed_chunk_count": len(chunks),
+        },
+        "bm25": {
+            "library": "bm25s",
+            "version": bm25_version,
+            "method": "lucene",
+            "k1": 1.5,
+            "b": 0.75,
+            "backend": "numpy",
+            "indexed_unit": "chunk",
+            "candidate_chunk_k": CANDIDATE_K,
+            "query_normalization": "rstrip",
+            "tokenizer_regex": (
+                r"[A-Za-z0-9]+(?:[._:/+-][A-Za-z0-9]+)*"
+            ),
+        },
+        "retrieval_dataset": retrieval_dataset,
+        "input_e0_train_results_sha256": (
+            actual_e0_sha
+        ),
+        "historical_e1_e0_train_results_sha256": (
+            historical_e0_sha
+        ),
+        "e0_train_results_sha_matches_historical": (
+            actual_e0_sha == historical_e0_sha
+        ),
+        "project_sha": _resolve_project_sha(),
+    }
+
+    preflight: dict[str, Any] = {
+        "split": "train",
+        "query_count": len(snapshot_records),
+        "document_count": len(documents),
+        "chunk_count": len(chunks),
+        "dense_candidate_k": CANDIDATE_K,
+        "bm25_candidate_k": CANDIDATE_K,
+        "rrf_k": RRF_K,
+        "fused_candidate_k": CANDIDATE_K,
+        "all_dense_rankings_unique": all(
+            len(set(record.dense_chunk_ids))
+            == CANDIDATE_K
+            for record in snapshot_records
+        ),
+        "all_bm25_rankings_unique": all(
+            len(set(record.bm25_chunk_ids))
+            == CANDIDATE_K
+            for record in snapshot_records
+        ),
+        "all_fused_rankings_unique": all(
+            len(
+                {
+                    candidate.chunk_id
+                    for candidate
+                    in record.fused_candidates
+                }
+            )
+            == CANDIDATE_K
+            for record in snapshot_records
+        ),
+        "snapshot_sha256": snapshot_sha,
+        "provider_calls": 0,
+        "dev_artifact_opened": False,
+        "reranker_model": DEFAULT_RERANK_MODEL,
+        "token_stop_threshold": (
+            TOKEN_STOP_THRESHOLD
+        ),
+        "monetary_safety_envelope_usd": (
+            MONETARY_SAFETY_ENVELOPE_USD
+        ),
+    }
+
+    if not (
+        preflight["all_dense_rankings_unique"]
+        and preflight["all_bm25_rankings_unique"]
+        and preflight["all_fused_rankings_unique"]
+    ):
+        raise RuntimeError(
+            "C1 candidate uniqueness preflight failed"
+        )
+
+    _write_json(
+        snapshot_manifest_path,
+        manifest,
+    )
+    _write_json(
+        preflight_path,
+        preflight,
+    )
+
+    print("[R4 C1] Frozen snapshot prepared.")
+    print(
+        json.dumps(
+            preflight,
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+    return preflight
+
+
+def main(
+    argv: Sequence[str] | None = None,
+) -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare the frozen TechQA R4 C1 Hybrid "
+            "candidate snapshot."
+        )
+    )
+    parser.add_argument(
+        "command",
+        choices=("prepare",),
+    )
+
+    args = parser.parse_args(
+        sys.argv[1:] if argv is None else argv
+    )
+
+    if args.command == "prepare":
+        prepare_frozen_snapshot()
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/evals/eval_techqa_hybrid_rerank.py
+++ b/experiments/evals/eval_techqa_hybrid_rerank.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from importlib.metadata import version
@@ -19,10 +20,15 @@ from experiments.evals.eval_techqa_chunk_bm25 import (
 from experiments.evals.eval_techqa_rerank import (
     load_frozen_e0_rerank_records,
 )
+from experiments.evals.ir.ranx_adapter import (
+    collapse_chunk_results_to_document_ranking,
+)
 from experiments.evals.ir.rrf import fuse_rrf
 from experiments.evals.rerankers.qwen3_reranker import (
     DEFAULT_RERANK_INSTRUCTION,
     DEFAULT_RERANK_MODEL,
+    RerankCandidate,
+    rerank_candidates,
 )
 from experiments.evals.retrievers.bm25_techqa_chunks import (
     TechQAChunk,
@@ -602,6 +608,88 @@ def prepare_frozen_snapshot(
 
     return preflight
 
+
+
+@dataclass(frozen=True)
+class HybridRerankResult:
+    question_id: str
+    relevant_document_ids: tuple[str, ...]
+    fused_chunk_ids: tuple[str, ...]
+    reranked_chunk_ids: tuple[str, ...]
+    reranked_document_ids: tuple[str, ...]
+    document_ranking: tuple[str, ...]
+    rerank_latency_ms: float
+    request_id: str | None
+    total_tokens: int | None
+
+
+def rerank_snapshot_record(
+    record: HybridSnapshotRecord,
+    *,
+    reranker: Callable[..., Any] = rerank_candidates,
+    clock: Callable[[], float] = time.perf_counter,
+) -> HybridRerankResult:
+    if not record.question_id.startswith("TRAIN_"):
+        raise RuntimeError("C1 requires TRAIN-only input")
+
+    fused_chunk_ids = _require_unique_exact(
+        [
+            candidate.chunk_id
+            for candidate in record.fused_candidates
+        ],
+        expected=CANDIDATE_K,
+        label="Hybrid rerank input",
+    )
+
+    candidates = [
+        RerankCandidate(
+            chunk_id=candidate.chunk_id,
+            document_id=candidate.document_id,
+            content=candidate.content,
+        )
+        for candidate in record.fused_candidates
+    ]
+
+    started = clock()
+
+    rerank_result = reranker(
+        record.question.rstrip(),
+        candidates,
+    )
+
+    rerank_latency_ms = (
+        clock() - started
+    ) * 1000.0
+
+    reranked_chunk_ids = tuple(
+        str(candidate.chunk_id)
+        for candidate in rerank_result.results
+    )
+
+    reranked_document_ids = tuple(
+        str(candidate.document_id)
+        for candidate in rerank_result.results
+    )
+
+    document_ranking = tuple(
+        collapse_chunk_results_to_document_ranking(
+            rerank_result.results
+        )
+    )
+
+    return HybridRerankResult(
+        question_id=record.question_id,
+        relevant_document_ids=(
+            record.relevant_document_ids
+        ),
+        fused_chunk_ids=fused_chunk_ids,
+        reranked_chunk_ids=reranked_chunk_ids,
+        reranked_document_ids=reranked_document_ids,
+        document_ranking=document_ranking,
+        rerank_latency_ms=rerank_latency_ms,
+        request_id=rerank_result.request_id,
+        total_tokens=rerank_result.total_tokens,
+    )
 
 def main(
     argv: Sequence[str] | None = None,

--- a/experiments/evals/eval_techqa_hybrid_rerank.py
+++ b/experiments/evals/eval_techqa_hybrid_rerank.py
@@ -3,6 +3,7 @@
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import time
@@ -11,6 +12,8 @@ from dataclasses import asdict, dataclass
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any
+
+from ranx import Run
 
 from experiments.evals.adapters.techqa import build_techqa_documents
 from experiments.evals.eval_techqa_chunk_bm25 import (
@@ -21,7 +24,9 @@ from experiments.evals.eval_techqa_rerank import (
     load_frozen_e0_rerank_records,
 )
 from experiments.evals.ir.ranx_adapter import (
+    build_ranx_qrels,
     collapse_chunk_results_to_document_ranking,
+    evaluate_ir_run,
 )
 from experiments.evals.ir.rrf import fuse_rrf
 from experiments.evals.rerankers.qwen3_reranker import (
@@ -691,26 +696,775 @@ def rerank_snapshot_record(
         total_tokens=rerank_result.total_tokens,
     )
 
+
+E1_RECALL_AT_5 = 0.6911111111111111
+E1_RECALL_AT_20 = 0.8155555555555556
+E1_MRR_AT_10 = 0.5672063492063492
+
+C1_MRR_AT_10_THRESHOLD = 0.5772063492063492
+C1_RECALL_AT_20_THRESHOLD = 365 / 450
+
+DEFAULT_CHECKPOINT_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_checkpoint.jsonl"
+)
+DEFAULT_INFLIGHT_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_inflight.json"
+)
+DEFAULT_RESULTS_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_results.jsonl"
+)
+DEFAULT_PAID_MANIFEST_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_manifest.json"
+)
+DEFAULT_METRICS_PATH = (
+    DEFAULT_OUTPUT_DIR / "train_metrics.json"
+)
+DEFAULT_COMPARISON_PATH = (
+    DEFAULT_OUTPUT_DIR / "comparison.md"
+)
+
+
+@dataclass(frozen=True)
+class HybridPaidEvalSummary:
+    completed_query_count: int
+    metrics: dict[str, float]
+    rerank_latency_p50_ms: float
+    rerank_latency_p95_ms: float
+    provider_total_tokens: int
+    stopped_reason: str | None
+    results: tuple[HybridRerankResult, ...]
+
+
+def _snapshot_record_from_payload(
+    payload: Mapping[str, Any],
+) -> HybridSnapshotRecord:
+    return HybridSnapshotRecord(
+        question_id=str(payload["question_id"]),
+        question=str(payload["question"]),
+        relevant_document_ids=tuple(
+            str(value)
+            for value in payload["relevant_document_ids"]
+        ),
+        dense_chunk_ids=tuple(
+            str(value)
+            for value in payload["dense_chunk_ids"]
+        ),
+        bm25_chunk_ids=tuple(
+            str(value)
+            for value in payload["bm25_chunk_ids"]
+        ),
+        fused_candidates=tuple(
+            HybridCandidate(
+                chunk_id=str(candidate["chunk_id"]),
+                document_id=str(candidate["document_id"]),
+                content=str(candidate["content"]),
+            )
+            for candidate in payload["fused_candidates"]
+        ),
+    )
+
+
+def load_validated_paid_snapshot(
+    *,
+    snapshot_path: str | Path,
+    manifest_path: str | Path,
+    expected_count: int = EXPECTED_TRAIN_COUNT,
+) -> list[HybridSnapshotRecord]:
+    snapshot = Path(snapshot_path)
+    manifest_source = Path(manifest_path)
+
+    if not snapshot.exists():
+        raise RuntimeError(
+            f"frozen snapshot missing: {snapshot}"
+        )
+
+    if not manifest_source.exists():
+        raise RuntimeError(
+            f"snapshot manifest missing: {manifest_source}"
+        )
+
+    manifest = json.loads(
+        manifest_source.read_text(encoding="utf-8")
+    )
+
+    if manifest.get("run") != "r4_c1_hybrid_rerank":
+        raise RuntimeError("invalid C1 snapshot manifest run")
+
+    if manifest.get("split") != "train":
+        raise RuntimeError(
+            "C1 paid path requires TRAIN-only snapshot"
+        )
+
+    manifest_count = int(manifest.get("query_count", -1))
+    if manifest_count != expected_count:
+        raise RuntimeError(
+            "snapshot manifest query count mismatch: "
+            f"expected={expected_count}, "
+            f"actual={manifest_count}"
+        )
+
+    expected_sha = str(
+        manifest.get("snapshot", {}).get("sha256", "")
+    )
+    actual_sha = _sha256(snapshot)
+
+    if actual_sha != expected_sha:
+        raise RuntimeError(
+            "snapshot SHA256 mismatch: "
+            f"expected={expected_sha}, actual={actual_sha}"
+        )
+
+    records: list[HybridSnapshotRecord] = []
+
+    for line in snapshot.read_text(
+        encoding="utf-8"
+    ).splitlines():
+        if not line.strip():
+            continue
+
+        record = _snapshot_record_from_payload(
+            json.loads(line)
+        )
+
+        if not record.question_id.startswith("TRAIN_"):
+            raise RuntimeError(
+                "C1 paid path requires TRAIN-only records"
+            )
+
+        if len(record.fused_candidates) != CANDIDATE_K:
+            raise RuntimeError(
+                "C1 paid snapshot requires exactly "
+                "100 fused candidates"
+            )
+
+        fused_chunk_ids = tuple(
+            candidate.chunk_id
+            for candidate in record.fused_candidates
+        )
+
+        _require_unique_exact(
+            fused_chunk_ids,
+            expected=CANDIDATE_K,
+            label="Hybrid paid candidate ranking",
+        )
+
+        _require_unique_exact(
+            record.dense_chunk_ids,
+            expected=CANDIDATE_K,
+            label="Dense frozen ranking",
+        )
+
+        _require_unique_exact(
+            record.bm25_chunk_ids,
+            expected=CANDIDATE_K,
+            label="BM25 frozen ranking",
+        )
+
+        records.append(record)
+
+    if len(records) != expected_count:
+        raise RuntimeError(
+            "snapshot record count mismatch: "
+            f"expected={expected_count}, "
+            f"actual={len(records)}"
+        )
+
+    question_ids = [
+        record.question_id
+        for record in records
+    ]
+
+    if len(set(question_ids)) != expected_count:
+        raise RuntimeError(
+            "snapshot contains duplicate question_id values"
+        )
+
+    return records
+
+
+def _paid_result_from_payload(
+    payload: Mapping[str, Any],
+) -> HybridRerankResult:
+    return HybridRerankResult(
+        question_id=str(payload["question_id"]),
+        relevant_document_ids=tuple(
+            str(value)
+            for value in payload["relevant_document_ids"]
+        ),
+        fused_chunk_ids=tuple(
+            str(value)
+            for value in payload["fused_chunk_ids"]
+        ),
+        reranked_chunk_ids=tuple(
+            str(value)
+            for value in payload["reranked_chunk_ids"]
+        ),
+        reranked_document_ids=tuple(
+            str(value)
+            for value in payload[
+                "reranked_document_ids"
+            ]
+        ),
+        document_ranking=tuple(
+            str(value)
+            for value in payload["document_ranking"]
+        ),
+        rerank_latency_ms=float(
+            payload["rerank_latency_ms"]
+        ),
+        request_id=(
+            None
+            if payload.get("request_id") is None
+            else str(payload["request_id"])
+        ),
+        total_tokens=(
+            None
+            if payload.get("total_tokens") is None
+            else int(payload["total_tokens"])
+        ),
+    )
+
+
+def _load_paid_checkpoint(
+    path: str | Path,
+) -> list[HybridRerankResult]:
+    source = Path(path)
+
+    if not source.exists():
+        return []
+
+    results: list[HybridRerankResult] = []
+
+    for line in source.read_text(
+        encoding="utf-8"
+    ).splitlines():
+        if not line.strip():
+            continue
+
+        results.append(
+            _paid_result_from_payload(
+                json.loads(line)
+            )
+        )
+
+    question_ids = [
+        result.question_id
+        for result in results
+    ]
+
+    if len(set(question_ids)) != len(question_ids):
+        raise RuntimeError(
+            "paid checkpoint contains duplicate question_id"
+        )
+
+    return results
+
+
+def _write_durable_json(
+    path: Path,
+    payload: Mapping[str, Any],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        encoding="utf-8",
+        newline="\n",
+    ) as file:
+        file.write(
+            json.dumps(
+                dict(payload),
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        file.flush()
+        os.fsync(file.fileno())
+
+
+def _append_durable_result(
+    path: Path,
+    result: HybridRerankResult,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "a",
+        encoding="utf-8",
+        newline="\n",
+    ) as file:
+        file.write(
+            json.dumps(
+                asdict(result),
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        file.flush()
+        os.fsync(file.fileno())
+
+
+def _paid_percentile(
+    values: Sequence[float],
+    percentile: float,
+) -> float:
+    if not values:
+        return 0.0
+
+    ordered = sorted(float(value) for value in values)
+
+    if len(ordered) == 1:
+        return ordered[0]
+
+    position = (len(ordered) - 1) * percentile
+    lower_index = int(position)
+    upper_index = min(
+        lower_index + 1,
+        len(ordered) - 1,
+    )
+    fraction = position - lower_index
+
+    return ordered[lower_index] + (
+        ordered[upper_index] - ordered[lower_index]
+    ) * fraction
+
+
+def _build_paid_summary(
+    results: Sequence[HybridRerankResult],
+    *,
+    stopped_reason: str | None,
+) -> HybridPaidEvalSummary:
+    ordered_results = sorted(
+        results,
+        key=lambda result: result.question_id,
+    )
+
+    if ordered_results:
+        qrels_by_query = {
+            result.question_id: {
+                document_id: 1
+                for document_id
+                in result.relevant_document_ids
+            }
+            for result in ordered_results
+        }
+
+        run_by_query: dict[str, dict[str, float]] = {}
+
+        for result in ordered_results:
+            ranking = result.document_ranking[:20]
+            ranking_size = len(ranking)
+
+            run_by_query[result.question_id] = {
+                document_id: float(
+                    ranking_size - rank
+                )
+                for rank, document_id
+                in enumerate(ranking)
+            }
+
+        metrics = evaluate_ir_run(
+            build_ranx_qrels(qrels_by_query),
+            Run(run_by_query),
+        )
+    else:
+        metrics = {
+            "recall@5": 0.0,
+            "recall@20": 0.0,
+            "mrr@10": 0.0,
+        }
+
+    latencies = [
+        result.rerank_latency_ms
+        for result in ordered_results
+    ]
+
+    return HybridPaidEvalSummary(
+        completed_query_count=len(ordered_results),
+        metrics=metrics,
+        rerank_latency_p50_ms=_paid_percentile(
+            latencies,
+            0.50,
+        ),
+        rerank_latency_p95_ms=_paid_percentile(
+            latencies,
+            0.95,
+        ),
+        provider_total_tokens=sum(
+            result.total_tokens or 0
+            for result in ordered_results
+        ),
+        stopped_reason=stopped_reason,
+        results=tuple(ordered_results),
+    )
+
+
+def run_resumable_paid_eval(
+    records: Sequence[HybridSnapshotRecord],
+    *,
+    evaluator: Callable[
+        [HybridSnapshotRecord],
+        HybridRerankResult,
+    ],
+    checkpoint_path: str | Path,
+    inflight_path: str | Path,
+    token_stop_threshold: int = TOKEN_STOP_THRESHOLD,
+) -> HybridPaidEvalSummary:
+    checkpoint = Path(checkpoint_path)
+    inflight = Path(inflight_path)
+
+    existing = _load_paid_checkpoint(checkpoint)
+
+    by_question_id = {
+        result.question_id: result
+        for result in existing
+    }
+
+    record_ids = [
+        record.question_id
+        for record in records
+    ]
+
+    if len(set(record_ids)) != len(record_ids):
+        raise RuntimeError(
+            "paid input contains duplicate question_id"
+        )
+
+    for record in records:
+        if not record.question_id.startswith("TRAIN_"):
+            raise RuntimeError(
+                "C1 paid path requires TRAIN-only records"
+            )
+
+        if len(record.fused_candidates) != CANDIDATE_K:
+            raise RuntimeError(
+                "C1 paid path requires exactly "
+                "100 fused candidates"
+            )
+
+    if inflight.exists():
+        inflight_payload = json.loads(
+            inflight.read_text(encoding="utf-8")
+        )
+        inflight_question_id = str(
+            inflight_payload["question_id"]
+        )
+
+        if inflight_question_id in by_question_id:
+            inflight.unlink()
+        else:
+            raise RuntimeError(
+                "inflight/uncertain provider request "
+                "requires manual review; automatic "
+                "replay is forbidden"
+            )
+
+    provider_total_tokens = sum(
+        result.total_tokens or 0
+        for result in by_question_id.values()
+    )
+
+    stopped_reason: str | None = None
+
+    for record in records:
+        question_id = record.question_id
+
+        if question_id in by_question_id:
+            continue
+
+        if provider_total_tokens >= token_stop_threshold:
+            stopped_reason = "token_stop_threshold"
+            break
+
+        _write_durable_json(
+            inflight,
+            {
+                "question_id": question_id,
+            },
+        )
+
+        # If evaluator/provider raises, the durable inflight
+        # marker intentionally remains for manual review.
+        result = evaluator(record)
+
+        if result.question_id != question_id:
+            raise RuntimeError(
+                "provider result question_id mismatch"
+            )
+
+        _append_durable_result(
+            checkpoint,
+            result,
+        )
+
+        by_question_id[question_id] = result
+        provider_total_tokens += (
+            result.total_tokens or 0
+        )
+
+        inflight.unlink()
+
+    return _build_paid_summary(
+        list(by_question_id.values()),
+        stopped_reason=stopped_reason,
+    )
+
+
+def evaluate_c1_gate(
+    summary: HybridPaidEvalSummary,
+) -> dict[str, Any]:
+    complete = (
+        summary.completed_query_count
+        == EXPECTED_TRAIN_COUNT
+    )
+
+    passed = (
+        complete
+        and summary.metrics["mrr@10"]
+        >= C1_MRR_AT_10_THRESHOLD
+        and summary.metrics["recall@20"]
+        >= C1_RECALL_AT_20_THRESHOLD
+    )
+
+    return {
+        "complete_train_run": complete,
+        "mrr@10_threshold": C1_MRR_AT_10_THRESHOLD,
+        "recall@20_threshold": (
+            C1_RECALL_AT_20_THRESHOLD
+        ),
+        "mrr@10_pass": (
+            summary.metrics["mrr@10"]
+            >= C1_MRR_AT_10_THRESHOLD
+        ),
+        "recall@20_pass": (
+            summary.metrics["recall@20"]
+            >= C1_RECALL_AT_20_THRESHOLD
+        ),
+        "c1_pass": passed,
+    }
+
+
+def write_paid_reports(
+    summary: HybridPaidEvalSummary,
+    *,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    snapshot_path: str | Path = DEFAULT_SNAPSHOT_PATH,
+    snapshot_manifest_path: str | Path = (
+        DEFAULT_SNAPSHOT_MANIFEST_PATH
+    ),
+) -> None:
+    output = Path(output_dir)
+    output.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    results_path = output / "train_results.jsonl"
+
+    with results_path.open(
+        "w",
+        encoding="utf-8",
+        newline="\n",
+    ) as file:
+        for result in summary.results:
+            file.write(
+                json.dumps(
+                    asdict(result),
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+    gate = evaluate_c1_gate(summary)
+
+    metrics_payload = {
+        "query_count": summary.completed_query_count,
+        "metrics": summary.metrics,
+        "rerank_latency_p50_ms": (
+            summary.rerank_latency_p50_ms
+        ),
+        "rerank_latency_p95_ms": (
+            summary.rerank_latency_p95_ms
+        ),
+        "provider_total_tokens": (
+            summary.provider_total_tokens
+        ),
+        "stopped_reason": summary.stopped_reason,
+        "gate": gate,
+    }
+
+    _write_json(
+        output / "train_metrics.json",
+        metrics_payload,
+    )
+
+    snapshot_manifest = json.loads(
+        Path(snapshot_manifest_path).read_text(
+            encoding="utf-8"
+        )
+    )
+
+    paid_manifest = {
+        "benchmark": "TechQA-RAG-Eval",
+        "run": "r4_c1_hybrid_rerank",
+        "split": "train",
+        "query_count": (
+            summary.completed_query_count
+        ),
+        "snapshot_sha256": _sha256(snapshot_path),
+        "snapshot_manifest_sha256": _sha256(
+            snapshot_manifest_path
+        ),
+        "candidate_contract": {
+            "dense_candidate_k": CANDIDATE_K,
+            "bm25_candidate_k": CANDIDATE_K,
+            "rrf_k": RRF_K,
+            "fused_candidate_k": CANDIDATE_K,
+        },
+        "reranker": {
+            "model": DEFAULT_RERANK_MODEL,
+            "instruction": DEFAULT_RERANK_INSTRUCTION,
+            "candidate_chunk_k": CANDIDATE_K,
+            "query_normalization": "rstrip",
+            "provider_region": (
+                snapshot_manifest["reranker"][
+                    "provider_region"
+                ]
+            ),
+            "sdk_max_retries": 0,
+        },
+        "paid_safety": {
+            "token_stop_threshold": (
+                TOKEN_STOP_THRESHOLD
+            ),
+            "monetary_safety_envelope_usd": (
+                MONETARY_SAFETY_ENVELOPE_USD
+            ),
+            "stopped_reason": (
+                summary.stopped_reason
+            ),
+        },
+        "provider_total_tokens": (
+            summary.provider_total_tokens
+        ),
+        "gate": gate,
+        "project_sha": _resolve_project_sha(),
+    }
+
+    _write_json(
+        output / "train_manifest.json",
+        paid_manifest,
+    )
+
+    metrics = summary.metrics
+
+    comparison = f"""# R4 C1 Hybrid + Rerank vs E1
+
+## Frozen E1 TRAIN baseline
+
+- Recall@5: {E1_RECALL_AT_5:.12f}
+- Recall@20: {E1_RECALL_AT_20:.12f}
+- MRR@10: {E1_MRR_AT_10:.12f}
+
+## R4 C1 TRAIN
+
+- completed queries: {summary.completed_query_count}
+- Recall@5: {metrics["recall@5"]:.12f}
+- Recall@20: {metrics["recall@20"]:.12f}
+- MRR@10: {metrics["mrr@10"]:.12f}
+- provider tokens: {summary.provider_total_tokens}
+- stopped reason: {summary.stopped_reason}
+
+## Pre-registered executable gate
+
+- MRR@10 >= {C1_MRR_AT_10_THRESHOLD:.16f}
+- Recall@20 >= {C1_RECALL_AT_20_THRESHOLD:.16f}
+- C1 PASS: {gate["c1_pass"]}
+
+Complete historical E1 per-query evidence is not preserved,
+so C1 does not rerun E1 solely to recreate paired diagnostics.
+"""
+
+    (
+        output / "comparison.md"
+    ).write_text(
+        comparison,
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def execute_paid_run() -> HybridPaidEvalSummary:
+    records = load_validated_paid_snapshot(
+        snapshot_path=DEFAULT_SNAPSHOT_PATH,
+        manifest_path=DEFAULT_SNAPSHOT_MANIFEST_PATH,
+        expected_count=EXPECTED_TRAIN_COUNT,
+    )
+
+    summary = run_resumable_paid_eval(
+        records,
+        evaluator=rerank_snapshot_record,
+        checkpoint_path=DEFAULT_CHECKPOINT_PATH,
+        inflight_path=DEFAULT_INFLIGHT_PATH,
+        token_stop_threshold=TOKEN_STOP_THRESHOLD,
+    )
+
+    write_paid_reports(summary)
+
+    return summary
+
+
 def main(
     argv: Sequence[str] | None = None,
 ) -> None:
     parser = argparse.ArgumentParser(
         description=(
-            "Prepare the frozen TechQA R4 C1 Hybrid "
-            "candidate snapshot."
+            "Prepare or execute the frozen TechQA "
+            "R4 C1 Hybrid rerank experiment."
         )
     )
     parser.add_argument(
         "command",
-        choices=("prepare",),
+        choices=("prepare", "paid"),
     )
 
     args = parser.parse_args(
-        sys.argv[1:] if argv is None else argv
+        sys.argv[1:]
+        if argv is None
+        else argv
     )
 
     if args.command == "prepare":
         prepare_frozen_snapshot()
+        return
+
+    summary = execute_paid_run()
+
+    print(
+        json.dumps(
+            {
+                "completed_query_count": (
+                    summary.completed_query_count
+                ),
+                "metrics": summary.metrics,
+                "provider_total_tokens": (
+                    summary.provider_total_tokens
+                ),
+                "stopped_reason": (
+                    summary.stopped_reason
+                ),
+                "gate": evaluate_c1_gate(summary),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/evals/eval_techqa_hybrid_rerank.py
+++ b/experiments/evals/eval_techqa_hybrid_rerank.py
@@ -1198,6 +1198,12 @@ def run_resumable_paid_eval(
                 "provider result question_id mismatch"
             )
 
+        if result.total_tokens is None:
+            raise RuntimeError(
+                "provider result missing total_tokens; "
+                "paid token accounting cannot continue"
+            )
+
         _append_durable_result(
             checkpoint,
             result,

--- a/experiments/evals/reports/cost_ledger.md
+++ b/experiments/evals/reports/cost_ledger.md
@@ -7,10 +7,19 @@ This ledger tracks model/API spend at experiment-stage granularity. Historical s
 | Completed E0/E1 | establish the baseline and test the ranking-error rerank hypothesis | mixed historical | historical | ≈ CNY 41 cumulative | frozen |
 | R2 | characterize E1 TRAIN residuals | local | CNY 0 | CNY 0 | pending |
 | R3 | test lexical complementarity with BM25/RRF | local | CNY 0 API | CNY 0 API | ADMIT_PAID_R4 |
-| R4 | test Hybrid candidate pool + rerank | qwen3-rerank | freeze before run | — | gated |
+| R4 C1 | test Hybrid candidate pool + rerank | qwen3-rerank | USD 1.50 safety envelope | 12,080,467 formal provider tokens; monetary billing not yet reconciled | STOP ? C1 failed pre-registered MRR gate |
 | G1 | test generator bottleneck on frozen context | candidate LLM | freeze before run | — | gated |
 | D1 | validate the final frozen generation configuration | final LLM/eval | final approval | — | gated |
 
 ## Governance rule
 
 Before any new paid stage begins, freeze its hypothesis, reusable artifacts, minimum model-call count, hard cost cap, stop condition, expected quantitative output, and resume/interview evidence. Record actual spend after the stage finishes. Bulk LLM-as-Judge evaluation is not a default action.
+
+## R4 C1 accounting note
+
+The formal 450-query C1 TRAIN run recorded 12,080,467 provider tokens.
+A separate successful three-document connectivity diagnostic recorded
+88 tokens and is excluded from the formal C1 metric/token total.
+Earlier rejected HTTP 400 and client-side URL/TLS failures do not have
+reliable provider token or billing evidence, so no monetary amount is
+invented for them.

--- a/experiments/evals/reports/r4_c1_hybrid_rerank/artifact_hashes.json
+++ b/experiments/evals/reports/r4_c1_hybrid_rerank/artifact_hashes.json
@@ -1,0 +1,20 @@
+{
+  "run": "r4_c1_hybrid_rerank",
+  "split": "train",
+  "large_local_artifacts": {
+    "train_fused_snapshot.jsonl": {
+      "sha256": "12db56e50efaf11dab4a28ff3c1b4df223e2ad985a8b48021f4c7dd9fdd889d2",
+      "bytes": 35537598
+    },
+    "train_checkpoint.jsonl": {
+      "sha256": "12b312a8403cda2c5fe8afe53aa18853891a7e87feaf863e2d438ca15367ee5b",
+      "bytes": 4057204
+    },
+    "train_results.jsonl": {
+      "sha256": "12b312a8403cda2c5fe8afe53aa18853891a7e87feaf863e2d438ca15367ee5b",
+      "bytes": 4057204
+    },
+    "checkpoint_equals_results": true
+  },
+  "versioning_policy": "Large snapshot/checkpoint/results remain local; repository stores compact evidence and SHA256 identities."
+}

--- a/experiments/evals/reports/r4_c1_hybrid_rerank/comparison.md
+++ b/experiments/evals/reports/r4_c1_hybrid_rerank/comparison.md
@@ -1,0 +1,40 @@
+# R4 C1 Hybrid + Rerank vs E1
+
+## Frozen E1 TRAIN baseline
+
+- Recall@5: 0.691111111111
+- Recall@20: 0.815555555556
+- MRR@10: 0.567206349206
+
+## R4 C1 TRAIN
+
+- completed queries: 450
+- Recall@5: 0.702222222222
+- Recall@20: 0.831111111111
+- MRR@10: 0.570929453263
+- provider tokens: 12080467
+- stopped reason: None
+
+## Pre-registered executable gate
+
+- MRR@10 >= 0.5772063492063492
+- Recall@20 >= 0.8111111111111111
+- C1 PASS: False
+
+Complete historical E1 per-query evidence is not preserved,
+so C1 does not rerun E1 solely to recreate paired diagnostics.
+
+## Decision
+
+C1 improved aggregate retrieval effectiveness over E1 on TRAIN:
+
+- Recall@5: 0.691111111111 -> 0.702222222222
+- Recall@20: 0.815555555556 -> 0.831111111111
+- MRR@10: 0.567206349206 -> 0.570929453263
+
+However, C1 failed the pre-registered MRR@10 threshold
+of 0.5772063492063492.
+
+Therefore the pre-registered C1 gate is FAIL.
+Paid R4 stops here and no C2 paid optimization is admitted.
+

--- a/experiments/evals/reports/r4_c1_hybrid_rerank/train_manifest.json
+++ b/experiments/evals/reports/r4_c1_hybrid_rerank/train_manifest.json
@@ -1,0 +1,37 @@
+{
+  "benchmark": "TechQA-RAG-Eval",
+  "run": "r4_c1_hybrid_rerank",
+  "split": "train",
+  "query_count": 450,
+  "snapshot_sha256": "12db56e50efaf11dab4a28ff3c1b4df223e2ad985a8b48021f4c7dd9fdd889d2",
+  "snapshot_manifest_sha256": "48983d7e2bef876e332f0ef9c33f2bdc827aed56f8b749e38ae9bb1690a52398",
+  "candidate_contract": {
+    "dense_candidate_k": 100,
+    "bm25_candidate_k": 100,
+    "rrf_k": 60,
+    "fused_candidate_k": 100
+  },
+  "reranker": {
+    "model": "qwen3-rerank",
+    "instruction": "Rank the candidate passages by relevance to resolving the technical support query.",
+    "candidate_chunk_k": 100,
+    "query_normalization": "rstrip",
+    "provider_region": "Singapore",
+    "sdk_max_retries": 0
+  },
+  "paid_safety": {
+    "token_stop_threshold": 13500000,
+    "monetary_safety_envelope_usd": 1.5,
+    "stopped_reason": null
+  },
+  "provider_total_tokens": 12080467,
+  "gate": {
+    "complete_train_run": true,
+    "mrr@10_threshold": 0.5772063492063492,
+    "recall@20_threshold": 0.8111111111111111,
+    "mrr@10_pass": false,
+    "recall@20_pass": true,
+    "c1_pass": false
+  },
+  "project_sha": "0bb586f4376d06d610b5528481722b052d5ea5e0"
+}

--- a/experiments/evals/reports/r4_c1_hybrid_rerank/train_metrics.json
+++ b/experiments/evals/reports/r4_c1_hybrid_rerank/train_metrics.json
@@ -1,0 +1,20 @@
+{
+  "query_count": 450,
+  "metrics": {
+    "recall@5": 0.7022222222222222,
+    "recall@20": 0.8311111111111111,
+    "mrr@10": 0.5709294532627865
+  },
+  "rerank_latency_p50_ms": 3059.273350001604,
+  "rerank_latency_p95_ms": 3588.326039999082,
+  "provider_total_tokens": 12080467,
+  "stopped_reason": null,
+  "gate": {
+    "complete_train_run": true,
+    "mrr@10_threshold": 0.5772063492063492,
+    "recall@20_threshold": 0.8111111111111111,
+    "mrr@10_pass": false,
+    "recall@20_pass": true,
+    "c1_pass": false
+  }
+}

--- a/experiments/evals/reports/r4_c1_hybrid_rerank/train_preflight.json
+++ b/experiments/evals/reports/r4_c1_hybrid_rerank/train_preflight.json
@@ -1,0 +1,19 @@
+{
+  "split": "train",
+  "query_count": 450,
+  "document_count": 28481,
+  "chunk_count": 172614,
+  "dense_candidate_k": 100,
+  "bm25_candidate_k": 100,
+  "rrf_k": 60,
+  "fused_candidate_k": 100,
+  "all_dense_rankings_unique": true,
+  "all_bm25_rankings_unique": true,
+  "all_fused_rankings_unique": true,
+  "snapshot_sha256": "12db56e50efaf11dab4a28ff3c1b4df223e2ad985a8b48021f4c7dd9fdd889d2",
+  "provider_calls": 0,
+  "dev_artifact_opened": false,
+  "reranker_model": "qwen3-rerank",
+  "token_stop_threshold": 13500000,
+  "monetary_safety_envelope_usd": 1.5
+}

--- a/experiments/evals/reports/r4_c1_hybrid_rerank/train_snapshot_manifest.json
+++ b/experiments/evals/reports/r4_c1_hybrid_rerank/train_snapshot_manifest.json
@@ -1,0 +1,78 @@
+{
+  "benchmark": "TechQA-RAG-Eval",
+  "run": "r4_c1_hybrid_rerank",
+  "split": "train",
+  "query_count": 450,
+  "provider_calls": 0,
+  "dev_artifact_opened": false,
+  "candidate_construction": {
+    "dense_candidate_k": 100,
+    "bm25_candidate_k": 100,
+    "rrf_k": 60,
+    "rrf_weights": "equal",
+    "rrf_unit": "chunk_id",
+    "fused_candidate_k": 100,
+    "cross_source_overlap_rule": "retain both source rank contributions"
+  },
+  "snapshot": {
+    "path": "experiments\\evals\\reports\\r4_c1_hybrid_rerank\\train_fused_snapshot.jsonl",
+    "sha256": "12db56e50efaf11dab4a28ff3c1b4df223e2ad985a8b48021f4c7dd9fdd889d2",
+    "format": "jsonl"
+  },
+  "reranker": {
+    "model": "qwen3-rerank",
+    "instruction": "Rank the candidate passages by relevance to resolving the technical support query.",
+    "candidate_chunk_k": 100,
+    "query_normalization": "rstrip",
+    "provider_region": "Singapore"
+  },
+  "paid_safety": {
+    "token_stop_threshold": 13500000,
+    "monetary_safety_envelope_usd": 1.5
+  },
+  "chunking": {
+    "strategy": "paragraph_aware_character",
+    "chunk_size": 800,
+    "chunk_overlap": 120,
+    "min_chunk_size": 150,
+    "splitter_blob_sha": "64026b4434f1eea46b95bfce9f667680a37a2103",
+    "observed_chunk_count": 172614
+  },
+  "bm25": {
+    "library": "bm25s",
+    "version": "0.3.10",
+    "method": "lucene",
+    "k1": 1.5,
+    "b": 0.75,
+    "backend": "numpy",
+    "indexed_unit": "chunk",
+    "candidate_chunk_k": 100,
+    "query_normalization": "rstrip",
+    "tokenizer_regex": "[A-Za-z0-9]+(?:[._:/+-][A-Za-z0-9]+)*"
+  },
+  "retrieval_dataset": {
+    "repo": "bowang0911/TechQA-RAG-Eval",
+    "revision": "68323f8f191fd5df93e2b2673d79a5da3a805638",
+    "license_declared": "apache-2.0",
+    "corpus_file": "corpus/train-00000-of-00001.parquet",
+    "queries_file": "queries/train-00000-of-00001.parquet",
+    "qrels_file": "data/train-00000-of-00001.parquet",
+    "corpus_sha256": "3c4c4fe05204efa99101a402dc4d1c6206bcd160eb20be28e6a0b594415b3edb",
+    "queries_sha256": "ac0151d80b930b07b4d4214ff7f914f9d74cbe9fca39d82a51a79a5ad9792fb9",
+    "qrels_sha256": "1e739923a9549d93c9613bb6d29ecfa747addef1d7cbadbb5ac8422b280c6735",
+    "loaded_corpus_documents": 28481,
+    "loaded_retrieval_queries": 610,
+    "qrels_rows": 610,
+    "unique_gold_documents": 496,
+    "qrels_per_query_distribution": {
+      "1": 610
+    },
+    "relevance_score_distribution": {
+      "1": 610
+    }
+  },
+  "input_e0_train_results_sha256": "c09401ea3ebd2774a0972a557436e1baff48cf317689b4ea44284ef44badfd82",
+  "historical_e1_e0_train_results_sha256": "4abf6365de33fe14adfbac2cd53669a434f5506b928fa890b3acd37e4d999953",
+  "e0_train_results_sha_matches_historical": false,
+  "project_sha": "61886eefa07ae04b609d4c111ef43921b9949f0a"
+}

--- a/experiments/evals/rerankers/qwen3_reranker.py
+++ b/experiments/evals/rerankers/qwen3_reranker.py
@@ -69,6 +69,35 @@ def get_rerank_client() -> OpenAI:
     )
 
 
+def _format_provider_error(error: Exception) -> str:
+    details = [str(error)]
+
+    status_code = getattr(error, "status_code", None)
+    if status_code is not None:
+        details.append(f"status_code={status_code}")
+
+    request_id = getattr(error, "request_id", None)
+    if request_id:
+        details.append(f"request_id={request_id}")
+
+    body = getattr(error, "body", None)
+
+    if isinstance(body, Mapping):
+        code = body.get("code")
+        message = body.get("message")
+
+        if code is not None:
+            details.append(f"code={code}")
+
+        if message is not None:
+            details.append(f"message={message}")
+
+    elif body is not None:
+        details.append(f"body={body}")
+
+    return "; ".join(details)
+
+
 def _as_mapping(value: Any, *, label: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise RerankProviderError(f"invalid rerank provider {label}")
@@ -96,7 +125,10 @@ def rerank_candidates(
     try:
         raw_response = provider.post("/reranks", body=body, cast_to=object)
     except Exception as error:
-        raise RerankProviderError(f"rerank provider failed: {error}") from error
+        raise RerankProviderError(
+            "rerank provider failed: "
+            + _format_provider_error(error)
+        ) from error
 
     response = _as_mapping(raw_response, label="response")
     raw_results = response.get("results")

--- a/experiments/evals/rerankers/qwen3_reranker.py
+++ b/experiments/evals/rerankers/qwen3_reranker.py
@@ -62,7 +62,11 @@ def get_rerank_client() -> OpenAI:
             "Missing required rerank configuration: " + ", ".join(missing)
         )
 
-    return OpenAI(api_key=api_key, base_url=base_url)
+    return OpenAI(
+        api_key=api_key,
+        base_url=base_url,
+        max_retries=0,
+    )
 
 
 def _as_mapping(value: Any, *, label: str) -> Mapping[str, Any]:

--- a/experiments/evals/rerankers/qwen3_reranker.py
+++ b/experiments/evals/rerankers/qwen3_reranker.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+
+import httpx
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -62,10 +64,15 @@ def get_rerank_client() -> OpenAI:
             "Missing required rerank configuration: " + ", ".join(missing)
         )
 
+    http_client = httpx.Client(
+        trust_env=False,
+    )
+
     return OpenAI(
         api_key=api_key,
         base_url=base_url,
         max_retries=0,
+        http_client=http_client,
     )
 
 

--- a/tests/test_eval_techqa_hybrid_rerank.py
+++ b/tests/test_eval_techqa_hybrid_rerank.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from experiments.evals.rerankers.qwen3_reranker import RerankedCandidate
+
 
 def _load_module():
     try:
@@ -69,3 +71,87 @@ def test_candidate_snapshot_contract_preserves_cross_source_rrf_credit():
     # This is the key C1 contract:
     # cross-source overlap must retain both RRF rank contributions.
     assert fused_ids[0] == "shared"
+
+
+def test_one_query_orchestration_preserves_frozen_candidates_and_provider_identity():
+    module = _load_module()
+
+    candidates = tuple(
+        module.HybridCandidate(
+            chunk_id=f"c{i}",
+            document_id=(
+                "shared-doc"
+                if i < 2
+                else f"doc{i}"
+            ),
+            content=f"content {i}",
+        )
+        for i in range(100)
+    )
+
+    record = module.HybridSnapshotRecord(
+        question_id="TRAIN_Q1",
+        question="technical query",
+        relevant_document_ids=("shared-doc",),
+        dense_chunk_ids=tuple(
+            f"d{i}"
+            for i in range(100)
+        ),
+        bm25_chunk_ids=tuple(
+            f"b{i}"
+            for i in range(100)
+        ),
+        fused_candidates=candidates,
+    )
+
+    class FakeResult:
+        def __init__(self):
+            self.results = tuple(
+                RerankedCandidate(
+                    chunk_id=candidates[index].chunk_id,
+                    document_id=candidates[index].document_id,
+                    content=candidates[index].content,
+                    original_index=index,
+                    relevance_score=float(100 - index),
+                )
+                for index in reversed(range(100))
+            )
+            self.request_id = "req-c1"
+            self.total_tokens = 12345
+
+    seen = {}
+
+    def fake_reranker(query, rerank_candidates):
+        seen["query"] = query
+        seen["chunk_ids"] = [
+            item.chunk_id
+            for item in rerank_candidates
+        ]
+        return FakeResult()
+
+    clock = iter([1.0, 1.25]).__next__
+
+    result = module.rerank_snapshot_record(
+        record,
+        reranker=fake_reranker,
+        clock=clock,
+    )
+
+    assert seen["query"] == "technical query"
+
+    assert seen["chunk_ids"] == [
+        f"c{i}"
+        for i in range(100)
+    ]
+
+    assert len(result.reranked_chunk_ids) == 100
+
+    assert result.document_ranking[0] == "doc99"
+
+    # c0/c1 both map to shared-doc, so first-occurrence
+    # document collapse yields 99 unique documents.
+    assert len(result.document_ranking) == 99
+
+    assert result.request_id == "req-c1"
+    assert result.total_tokens == 12345
+    assert result.rerank_latency_ms == 250.0

--- a/tests/test_eval_techqa_hybrid_rerank.py
+++ b/tests/test_eval_techqa_hybrid_rerank.py
@@ -1,0 +1,71 @@
+﻿from importlib import import_module
+
+import pytest
+
+
+def _load_module():
+    try:
+        return import_module("experiments.evals.eval_techqa_hybrid_rerank")
+    except ModuleNotFoundError:
+        pytest.fail("R4 C1 hybrid rerank evaluator is not implemented yet")
+
+
+def test_candidate_snapshot_contract_preserves_cross_source_rrf_credit():
+    module = _load_module()
+
+    dense_ids = [f"d{i}" for i in range(99)]
+    bm25_ids = [f"b{i}" for i in range(99)]
+
+    # The shared chunk is rank 50 in both sources.
+    # Its two RRF contributions must beat a rank-1 chunk
+    # that appears in only one source.
+    dense_ids.insert(49, "shared")
+    bm25_ids.insert(49, "shared")
+
+    all_ids = set(dense_ids) | set(bm25_ids)
+
+    chunks_by_id = {
+        chunk_id: module.TechQAChunk(
+            chunk_id=chunk_id,
+            document_id=f"doc-{chunk_id}",
+            chunk_index=0,
+            content=f"content for {chunk_id}",
+        )
+        for chunk_id in all_ids
+    }
+
+    record = {
+        "question_id": "TRAIN_Q1",
+        "question": "shared technical query",
+        "relevant_document_ids": ["doc-shared"],
+        "raw_chunk_ids": dense_ids,
+    }
+
+    bm25_chunks = [
+        chunks_by_id[chunk_id]
+        for chunk_id in bm25_ids
+    ]
+
+    result = module.build_hybrid_snapshot_record(
+        record,
+        chunks_by_id=chunks_by_id,
+        bm25_searcher=lambda query, top_k: bm25_chunks[:top_k],
+    )
+
+    assert len(result.dense_chunk_ids) == 100
+    assert len(set(result.dense_chunk_ids)) == 100
+
+    assert len(result.bm25_chunk_ids) == 100
+    assert len(set(result.bm25_chunk_ids)) == 100
+
+    fused_ids = [
+        candidate.chunk_id
+        for candidate in result.fused_candidates
+    ]
+
+    assert len(fused_ids) == 100
+    assert len(set(fused_ids)) == 100
+
+    # This is the key C1 contract:
+    # cross-source overlap must retain both RRF rank contributions.
+    assert fused_ids[0] == "shared"

--- a/tests/test_eval_techqa_hybrid_rerank.py
+++ b/tests/test_eval_techqa_hybrid_rerank.py
@@ -522,7 +522,41 @@ def test_paid_runner_safety_contract(tmp_path, monkeypatch):
     assert uncertain_calls == []
 
     # --------------------------------------------------------
-    # 9. qwen3-rerank SDK automatic retries must be disabled.
+    # 9. Missing provider token usage must fail closed.
+    # --------------------------------------------------------
+
+    missing_token_checkpoint = (
+        tmp_path / "missing-token-checkpoint.jsonl"
+    )
+    missing_token_inflight = (
+        tmp_path / "missing-token-inflight.json"
+    )
+
+    def missing_token_evaluator(record):
+        return completed_result(
+            record.question_id,
+            total_tokens=None,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="total_tokens",
+    ):
+        module.run_resumable_paid_eval(
+            [record],
+            evaluator=missing_token_evaluator,
+            checkpoint_path=missing_token_checkpoint,
+            inflight_path=missing_token_inflight,
+        )
+
+    assert json.loads(
+        missing_token_inflight.read_text(
+            encoding="utf-8",
+        )
+    )["question_id"] == "TRAIN_Q1"
+
+    # --------------------------------------------------------
+    # 10. qwen3-rerank SDK automatic retries must be disabled.
     # --------------------------------------------------------
 
     from experiments.evals.rerankers import (

--- a/tests/test_eval_techqa_hybrid_rerank.py
+++ b/tests/test_eval_techqa_hybrid_rerank.py
@@ -155,3 +155,400 @@ def test_one_query_orchestration_preserves_frozen_candidates_and_provider_identi
     assert result.request_id == "req-c1"
     assert result.total_tokens == 12345
     assert result.rerank_latency_ms == 250.0
+
+
+def test_paid_runner_safety_contract(tmp_path, monkeypatch):
+    import hashlib
+    import json
+    from dataclasses import asdict
+
+    module = _load_module()
+
+    def make_record(
+        question_id="TRAIN_Q1",
+        *,
+        candidate_count=100,
+    ):
+        candidates = tuple(
+            module.HybridCandidate(
+                chunk_id=f"{question_id}-c{i}",
+                document_id=f"{question_id}-doc{i}",
+                content=f"content {i}",
+            )
+            for i in range(candidate_count)
+        )
+
+        return module.HybridSnapshotRecord(
+            question_id=question_id,
+            question="technical query",
+            relevant_document_ids=(
+                f"{question_id}-doc0",
+            ),
+            dense_chunk_ids=tuple(
+                f"{question_id}-d{i}"
+                for i in range(100)
+            ),
+            bm25_chunk_ids=tuple(
+                f"{question_id}-b{i}"
+                for i in range(100)
+            ),
+            fused_candidates=candidates,
+        )
+
+    def write_snapshot(records, path):
+        path.write_text(
+            "".join(
+                json.dumps(
+                    asdict(record),
+                    separators=(",", ":"),
+                )
+                + "\n"
+                for record in records
+            ),
+            encoding="utf-8",
+        )
+
+        return hashlib.sha256(
+            path.read_bytes()
+        ).hexdigest()
+
+    def write_manifest(path, snapshot_sha):
+        path.write_text(
+            json.dumps(
+                {
+                    "run": "r4_c1_hybrid_rerank",
+                    "split": "train",
+                    "query_count": 1,
+                    "snapshot": {
+                        "sha256": snapshot_sha,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def completed_result(
+        question_id,
+        *,
+        total_tokens,
+    ):
+        return module.HybridRerankResult(
+            question_id=question_id,
+            relevant_document_ids=(
+                f"{question_id}-doc0",
+            ),
+            fused_chunk_ids=tuple(
+                f"{question_id}-c{i}"
+                for i in range(100)
+            ),
+            reranked_chunk_ids=tuple(
+                f"{question_id}-c{i}"
+                for i in range(100)
+            ),
+            reranked_document_ids=tuple(
+                f"{question_id}-doc{i}"
+                for i in range(100)
+            ),
+            document_ranking=tuple(
+                f"{question_id}-doc{i}"
+                for i in range(100)
+            ),
+            rerank_latency_ms=100.0,
+            request_id=f"req-{question_id}",
+            total_tokens=total_tokens,
+        )
+
+    # --------------------------------------------------------
+    # 1. Valid frozen snapshot loads.
+    # --------------------------------------------------------
+
+    snapshot_path = tmp_path / "snapshot.jsonl"
+    manifest_path = tmp_path / "manifest.json"
+
+    record = make_record()
+    snapshot_sha = write_snapshot(
+        [record],
+        snapshot_path,
+    )
+    write_manifest(
+        manifest_path,
+        snapshot_sha,
+    )
+
+    loaded = module.load_validated_paid_snapshot(
+        snapshot_path=snapshot_path,
+        manifest_path=manifest_path,
+        expected_count=1,
+    )
+
+    assert len(loaded) == 1
+    assert loaded[0].question_id == "TRAIN_Q1"
+
+    # --------------------------------------------------------
+    # 2. Snapshot SHA mismatch must fail before paid work.
+    # --------------------------------------------------------
+
+    bad_manifest_path = tmp_path / "bad-manifest.json"
+    write_manifest(
+        bad_manifest_path,
+        "0" * 64,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="snapshot SHA256 mismatch",
+    ):
+        module.load_validated_paid_snapshot(
+            snapshot_path=snapshot_path,
+            manifest_path=bad_manifest_path,
+            expected_count=1,
+        )
+
+    # --------------------------------------------------------
+    # 3. Candidate count != 100 must fail before paid work.
+    # --------------------------------------------------------
+
+    bad_snapshot_path = tmp_path / "bad-snapshot.jsonl"
+    bad_record = make_record(
+        candidate_count=99,
+    )
+    bad_snapshot_sha = write_snapshot(
+        [bad_record],
+        bad_snapshot_path,
+    )
+
+    bad_candidate_manifest = (
+        tmp_path / "bad-candidate-manifest.json"
+    )
+    write_manifest(
+        bad_candidate_manifest,
+        bad_snapshot_sha,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="exactly 100 fused candidates",
+    ):
+        module.load_validated_paid_snapshot(
+            snapshot_path=bad_snapshot_path,
+            manifest_path=bad_candidate_manifest,
+            expected_count=1,
+        )
+
+    # --------------------------------------------------------
+    # 4. DEV is forbidden.
+    # --------------------------------------------------------
+
+    dev_snapshot_path = tmp_path / "dev-snapshot.jsonl"
+    dev_record = make_record(
+        question_id="DEV_Q1",
+    )
+    dev_snapshot_sha = write_snapshot(
+        [dev_record],
+        dev_snapshot_path,
+    )
+
+    dev_manifest_path = tmp_path / "dev-manifest.json"
+    write_manifest(
+        dev_manifest_path,
+        dev_snapshot_sha,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="TRAIN-only",
+    ):
+        module.load_validated_paid_snapshot(
+            snapshot_path=dev_snapshot_path,
+            manifest_path=dev_manifest_path,
+            expected_count=1,
+        )
+
+    # --------------------------------------------------------
+    # 5. Completed checkpoint query must never be replayed.
+    # --------------------------------------------------------
+
+    checkpoint_path = tmp_path / "checkpoint.jsonl"
+    checkpoint_path.write_text(
+        json.dumps(
+            asdict(
+                completed_result(
+                    "TRAIN_Q1",
+                    total_tokens=100,
+                )
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    inflight_path = tmp_path / "inflight.json"
+
+    evaluator_calls = []
+
+    def must_not_call(record):
+        evaluator_calls.append(record.question_id)
+        raise AssertionError(
+            "completed query was replayed"
+        )
+
+    summary = module.run_resumable_paid_eval(
+        [record],
+        evaluator=must_not_call,
+        checkpoint_path=checkpoint_path,
+        inflight_path=inflight_path,
+    )
+
+    assert evaluator_calls == []
+    assert summary.completed_query_count == 1
+
+    # --------------------------------------------------------
+    # 6. Token threshold prevents the next provider request.
+    # --------------------------------------------------------
+
+    second_record = make_record(
+        question_id="TRAIN_Q2",
+    )
+
+    threshold_checkpoint = (
+        tmp_path / "threshold-checkpoint.jsonl"
+    )
+    threshold_checkpoint.write_text(
+        json.dumps(
+            asdict(
+                completed_result(
+                    "TRAIN_Q1",
+                    total_tokens=13_500_000,
+                )
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    threshold_calls = []
+
+    def threshold_evaluator(record):
+        threshold_calls.append(record.question_id)
+        raise AssertionError(
+            "provider called after token threshold"
+        )
+
+    summary = module.run_resumable_paid_eval(
+        [record, second_record],
+        evaluator=threshold_evaluator,
+        checkpoint_path=threshold_checkpoint,
+        inflight_path=(
+            tmp_path / "threshold-inflight.json"
+        ),
+    )
+
+    assert threshold_calls == []
+    assert summary.provider_total_tokens == 13_500_000
+    assert summary.stopped_reason == "token_stop_threshold"
+
+    # --------------------------------------------------------
+    # 7. Provider failure leaves inflight state durable.
+    # --------------------------------------------------------
+
+    error_checkpoint = (
+        tmp_path / "error-checkpoint.jsonl"
+    )
+    error_inflight = (
+        tmp_path / "error-inflight.json"
+    )
+
+    def failing_evaluator(record):
+        raise RuntimeError("provider boom")
+
+    with pytest.raises(
+        RuntimeError,
+        match="provider boom",
+    ):
+        module.run_resumable_paid_eval(
+            [record],
+            evaluator=failing_evaluator,
+            checkpoint_path=error_checkpoint,
+            inflight_path=error_inflight,
+        )
+
+    assert json.loads(
+        error_inflight.read_text(
+            encoding="utf-8",
+        )
+    )["question_id"] == "TRAIN_Q1"
+
+    # --------------------------------------------------------
+    # 8. Uncertain inflight query cannot auto-replay.
+    # --------------------------------------------------------
+
+    uncertain_checkpoint = (
+        tmp_path / "uncertain-checkpoint.jsonl"
+    )
+    uncertain_inflight = (
+        tmp_path / "uncertain-inflight.json"
+    )
+
+    uncertain_inflight.write_text(
+        json.dumps(
+            {
+                "question_id": "TRAIN_Q1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    uncertain_calls = []
+
+    def uncertain_evaluator(record):
+        uncertain_calls.append(
+            record.question_id
+        )
+        raise AssertionError(
+            "uncertain request was replayed"
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="inflight/uncertain",
+    ):
+        module.run_resumable_paid_eval(
+            [record],
+            evaluator=uncertain_evaluator,
+            checkpoint_path=uncertain_checkpoint,
+            inflight_path=uncertain_inflight,
+        )
+
+    assert uncertain_calls == []
+
+    # --------------------------------------------------------
+    # 9. qwen3-rerank SDK automatic retries must be disabled.
+    # --------------------------------------------------------
+
+    from experiments.evals.rerankers import (
+        qwen3_reranker,
+    )
+
+    captured_kwargs = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(
+        qwen3_reranker,
+        "OpenAI",
+        FakeOpenAI,
+    )
+    monkeypatch.setenv(
+        "DASHSCOPE_RERANK_API_KEY",
+        "test-key",
+    )
+    monkeypatch.setenv(
+        "DASHSCOPE_RERANK_BASE_URL",
+        "https://example.invalid/v1",
+    )
+
+    qwen3_reranker.get_rerank_client()
+
+    assert captured_kwargs["max_retries"] == 0

--- a/tests/test_qwen3_reranker.py
+++ b/tests/test_qwen3_reranker.py
@@ -91,7 +91,31 @@ def test_qwen3_reranker_rejects_incomplete_provider_permutation():
 def test_qwen3_reranker_surfaces_provider_failure_without_dense_fallback():
     reranker = _reranker_module()
     candidates = [reranker.RerankCandidate("c0", "d0", "zero")]
-    client = FakeRerankClient(error=RuntimeError("provider unavailable"))
 
-    with pytest.raises(reranker.RerankProviderError, match="provider unavailable"):
-        reranker.rerank_candidates("question", candidates, client=client)
+    class FakeBadRequestError(Exception):
+        status_code = 400
+        request_id = "req-400"
+        body = {
+            "code": "InvalidParameter",
+            "message": "documents invalid",
+        }
+
+    client = FakeRerankClient(
+        error=FakeBadRequestError("Bad Request")
+    )
+
+    with pytest.raises(reranker.RerankProviderError) as exc_info:
+        reranker.rerank_candidates(
+            "question",
+            candidates,
+            client=client,
+        )
+
+    message = str(exc_info.value)
+
+    assert "Bad Request" in message
+    assert "status_code=400" in message
+    assert "request_id=req-400" in message
+    assert "InvalidParameter" in message
+    assert "documents invalid" in message
+    assert len(client.calls) == 1

--- a/tests/test_qwen3_reranker_client.py
+++ b/tests/test_qwen3_reranker_client.py
@@ -45,9 +45,10 @@ def test_get_rerank_client_uses_only_dedicated_rerank_environment(monkeypatch):
     observed = {}
 
     class FakeOpenAI:
-        def __init__(self, *, api_key, base_url):
+        def __init__(self, *, api_key, base_url, max_retries):
             observed["api_key"] = api_key
             observed["base_url"] = base_url
+            observed["max_retries"] = max_retries
 
     monkeypatch.setattr(reranker, "OpenAI", FakeOpenAI, raising=False)
 
@@ -58,6 +59,7 @@ def test_get_rerank_client_uses_only_dedicated_rerank_environment(monkeypatch):
         "base_url": (
             "https://workspace.ap-southeast-1.maas.aliyuncs.com/compatible-api/v1"
         ),
+        "max_retries": 0,
     }
 
 

--- a/tests/test_qwen3_reranker_client.py
+++ b/tests/test_qwen3_reranker_client.py
@@ -44,23 +44,52 @@ def test_get_rerank_client_uses_only_dedicated_rerank_environment(monkeypatch):
 
     observed = {}
 
+    class FakeHttpClient:
+        pass
+
+    class FakeHttpx:
+        @staticmethod
+        def Client(*, trust_env):
+            observed["http_trust_env"] = trust_env
+            return FakeHttpClient()
+
     class FakeOpenAI:
-        def __init__(self, *, api_key, base_url, max_retries):
+        def __init__(
+            self,
+            *,
+            api_key,
+            base_url,
+            max_retries,
+            http_client=None,
+        ):
             observed["api_key"] = api_key
             observed["base_url"] = base_url
             observed["max_retries"] = max_retries
+            observed["http_client"] = http_client
 
-    monkeypatch.setattr(reranker, "OpenAI", FakeOpenAI, raising=False)
+    monkeypatch.setattr(
+        reranker,
+        "httpx",
+        FakeHttpx,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        reranker,
+        "OpenAI",
+        FakeOpenAI,
+        raising=False,
+    )
 
     getter()
 
-    assert observed == {
-        "api_key": "rerank-key",
-        "base_url": (
-            "https://workspace.ap-southeast-1.maas.aliyuncs.com/compatible-api/v1"
-        ),
-        "max_retries": 0,
-    }
+    assert observed["api_key"] == "rerank-key"
+    assert observed["base_url"] == (
+        "https://workspace.ap-southeast-1.maas.aliyuncs.com/compatible-api/v1"
+    )
+    assert observed["max_retries"] == 0
+    assert observed.get("http_trust_env") is False
+    assert isinstance(observed["http_client"], FakeHttpClient)
+
 
 
 def test_get_rerank_client_rejects_missing_dedicated_config_even_if_chat_config_exists(


### PR DESCRIPTION
## Summary

- add the frozen R4 C1 chunk-level Hybrid + Rerank evaluation pipeline for TechQA TRAIN
- fuse Dense Top-100 and BM25 Top-100 chunk rankings with equal-weight RRF (`k=60`), then rerank the fused Top-100 with `qwen3-rerank`
- add paid-run safety controls: frozen snapshot validation, resumable checkpoints, inflight markers, token stop threshold, fail-closed token accounting, SDK retries disabled, and explicit provider error reporting
- bypass environment/system proxy use for the dedicated rerank client with `httpx.Client(trust_env=False)`
- version compact C1 evidence and SHA256 identities while keeping large snapshot/checkpoint/results and diagnostic inflight artifacts local
- update the evaluation cost ledger with the completed C1 accounting and stop decision

## R4 C1 TRAIN result

Frozen E1 baseline:
- Recall@5: `0.691111111111`
- Recall@20: `0.815555555556`
- MRR@10: `0.567206349206`

C1:
- completed queries: `450`
- Recall@5: `0.702222222222`
- Recall@20: `0.831111111111`
- MRR@10: `0.570929453263`
- provider tokens: `12,080,467`
- stopped reason: `null`

Pre-registered gate:
- MRR@10 >= `0.5772063492063492` -> **FAIL**
- Recall@20 >= `0.8111111111111111` -> **PASS**
- overall C1 -> **FAIL**

Decision: C1 improves recall but does not meet the pre-registered MRR gate, so paid R4 stops here and no C2 paid optimization is admitted.

A separate 3-document connectivity diagnostic consumed 88 tokens and is intentionally excluded from the formal C1 token total. Earlier rejected HTTP 400 and client-side URL/TLS failures do not have reliable provider token/billing evidence, so no monetary spend is invented for them.

## Verification

- `pytest -q` -> `287 passed in 25.05s`
- `ruff check .` -> `All checks passed!`
- final worktree status clean before push

## Repository evidence

Large local payloads remain unversioned; the repository contains compact manifests, metrics, comparison evidence, and SHA256 identities for the frozen snapshot/checkpoint/results.