### PR TITLE
Add G1 document-local evidence experiment and closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,35 @@ Harness 已包含：
 - end-to-end latency；
 - frozen run identity / manifest / checkpoint。
 
-> **结果边界：** 当前不声称该 context policy 已带来新的正式 generation uplift；在冻结评测完成前，只将其作为基于 failure diagnosis 实现的工程 intervention。
+## G1：Document-local evidence candidate
+
+在 E1 的 document-aware forward expansion 之后，项目进一步测试 G1：先从历史 E0 排名中取前 5 个 unique documents，展开这些文档的 frozen full chunks，再用同一 `qwen3-rerank` instruction 做一次 merged rerank，最终保留 Top16 evidence chunks。
+
+30-case method-label-blinded evidence-sufficiency 结果：
+
+| Metric | E1 | G1 |
+| --- | ---: | ---: |
+| COMPLETE | 24 / 30 | **28 / 30** |
+| PARTIAL | 1 / 30 | 1 / 30 |
+| INSUFFICIENT | 5 / 30 | **1 / 30** |
+| Macro claim coverage | 0.825000 | **0.955556** |
+
+G1 相对 E1 为 **6 wins / 22 ties / 2 losses**。但其中 `TRAIN_Q346` 触发了预注册 catastrophic regression：`E1=COMPLETE`、`G1=INSUFFICIENT`。因此正式结论是：
+
+```text
+aggregate evidence sufficiency: improved
+catastrophic-regression gate: FAIL
+G1 decision: NO_GO
+current reference: E1
+```
+
+后续对全部 65 个 frozen claims 的 transition forensic 显示：G1 新增覆盖 6 个 claims、丢失 2 个 claims；两条 regression 分别是一个 candidate-document admission miss（Q346）和一个 continuity miss（Q492），且都没有在其他 case 重复形成系统性模式。因此不针对已经看过的 TRAIN case 继续 patch G1。
+
+完整报告：
+
+- [experiments/evals/reports/g1_document_local/final_decision.md](experiments/evals/reports/g1_document_local/final_decision.md)
+
+> **结果边界：** G1 的 95.6% 是冻结 conditional Stage2 evidence-sufficiency experiment 的 macro claim coverage，不是 production generation accuracy，也不表示 G1 已替代 E1。当前仍以 E1 为 reference，G1 保留为 evaluated experimental candidate。
 
 ---
 
@@ -569,7 +597,8 @@ Workflow：
 - 不把 Demo JWT + tenant scope 写成完整生产级 IAM / multi-tenant isolation；
 - 不把 Docker Compose 写成生产部署；
 - 不把 approval `pending` 校验写成并发 exactly-once guarantee；
-- 不在正式 frozen generation evaluation 完成前声称 document-aware context expansion 带来生成质量提升；
+- 不把 G1 conditional evidence-sufficiency 改善写成 production generation uplift，也不声称 G1 已替代 E1；
+- 不针对 Q346 / Q492 已知 TRAIN regression 做 case-specific patch 后再把原 30-case 样本当作 fresh validation；
 - 不声称当前系统已具备完整 multi-source / conflict-resolution / autonomous Agentic RAG 能力。
 
 项目当前关注的是：

--- a/experiments/evals/README.md
+++ b/experiments/evals/README.md
@@ -240,9 +240,52 @@ Implementation:
 
 - `eval_techqa_generation.py`
 
+### G1 document-local evidence experiment
+
+G1 tested a different Stage2 evidence-construction hypothesis without promoting it into the serving path:
+
+```text
+historical E0 ranking
+   ↓
+first 5 unique candidate documents
+   ↓
+full frozen document-local chunks
+   ↓
+merged qwen3-rerank
+   ↓
+Top16 evidence chunks
+```
+
+The formal 30-case method-label-blinded comparison against E1 produced:
+
+| Metric | E1 | G1 |
+| --- | ---: | ---: |
+| COMPLETE | 24 / 30 | **28 / 30** |
+| PARTIAL | 1 / 30 | 1 / 30 |
+| INSUFFICIENT | 5 / 30 | **1 / 30** |
+| Macro claim coverage | 0.825000 | **0.955556** |
+
+Pairwise movement was **6 wins / 22 ties / 2 losses** for G1. However, one loss (`TRAIN_Q346`) met the preregistered catastrophic-regression definition `E1=COMPLETE && G1=INSUFFICIENT`.
+
+Therefore:
+
+```text
+aggregate evidence sufficiency: improved
+preregistered catastrophic-regression gate: failed
+formal G1 decision: NO_GO
+reference policy: keep E1
+```
+
+A 65-claim transition forensic found 6 newly covered claims and 2 lost claims. The two regressions had different, non-repeating boundaries: one candidate-document admission miss (`TRAIN_Q346`) and one continuity miss (`TRAIN_Q492`). Because neither mechanism repeated elsewhere in the frozen sample, the project does not patch G1 against those already-inspected TRAIN cases.
+
+Full closeout:
+
+- `reports/g1_document_local/final_decision.md`
+- `reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json`
+
 Important boundary:
 
-> The policy is implemented and test-covered, but this README does **not** claim a new formal generation uplift until the frozen generation evaluation supports that claim.
+> The G1 result is a conditional evidence-sufficiency experiment on TRAIN cases under a frozen Stage2 contract. It is **not** a production generation uplift, a full-TechQA retrieval improvement, or evidence that G1 replaced E1.
 
 ---
 
@@ -256,7 +299,8 @@ Do not:
 - hard-code question IDs to document IDs;
 - tune a frozen comparison from individual DEV failures;
 - remove difficult cases to improve reported metrics;
-- report TRAIN tuning results as held-out DEV gains.
+- report TRAIN tuning results as held-out DEV gains;
+- patch Q346/Q492-specific rules and present the same 30-case sample as fresh validation.
 
 The goal is to preserve a benchmark that can still falsify an optimization hypothesis.
 
@@ -300,9 +344,13 @@ Evidence-level audit
         ↓
 Candidate coverage vs evidence-ranking diagnosis
         ↓
-Document-aware context intervention
+E1 document-aware context policy
         ↓
-Generation / abstention evaluation harness
+G1 document-local evidence experiment
+        ↓
+aggregate gain + catastrophic gate failure → NO_GO
+        ↓
+keep E1 reference; preserve G1 as experimental candidate
 ```
 
 The value of this lineage is not that every experiment wins. The value is that each result determines the next engineering question without resetting the corpus, benchmark, or evaluation contract.
@@ -323,7 +371,10 @@ experiments/evals/
 │   ├── e1_rerank/
 │   ├── r4_c1_hybrid_rerank/
 │   ├── r1_evidence_audit/
-│   └── g0_generation/
+│   ├── g0_generation/
+│   └── g1_document_local/
+│       ├── evidence_sufficiency_30case_preregistration_v1_1.json
+│       └── final_decision.md
 ├── eval_techqa_generation.py
 ├── eval_techqa_hybrid_rerank.py
 └── rerankers/
@@ -343,7 +394,8 @@ Current claims are intentionally bounded:
 - online RAG remains Dense Chroma unless runtime code says otherwise;
 - Hybrid / RRF / reranking experiments remain offline evaluation evidence unless explicitly promoted into serving;
 - evidence-level audit is diagnostic and does not replace official document metrics;
-- generation uplift is not claimed before frozen evaluation is complete;
+- G1 improved evidence sufficiency in its frozen conditional 30-case experiment but failed its preregistered catastrophic-regression gate and therefore does not replace E1;
+- generation uplift is not claimed before frozen generation evaluation is complete;
 - multi-source / conflict-resolution / autonomous Agentic RAG capability is not claimed by this benchmark.
 
 If new stress sets are added later, they should extend this evaluation system rather than replace the existing TechQA lineage and force a new primary-corpus embedding / benchmark reset.

--- a/experiments/evals/eval_techqa_generation.py
+++ b/experiments/evals/eval_techqa_generation.py
@@ -111,6 +111,28 @@ class G0RetrievedChunk:
     distance: float
 
 
+def select_candidate_document_ids(
+    ranked_chunks: Sequence[G0RetrievedChunk],
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    seen: set[str] = set()
+    selected: list[str] = []
+    for chunk in ranked_chunks:
+        if chunk.document_id in seen:
+            continue
+
+        seen.add(chunk.document_id)
+        selected.append(chunk.document_id)
+        if len(selected) >= limit:
+            break
+
+    return tuple(selected)
+
+
 @dataclass(frozen=True)
 class G0RetrievalOutcome:
     results: tuple[G0RetrievedChunk, ...]

--- a/experiments/evals/eval_techqa_generation.py
+++ b/experiments/evals/eval_techqa_generation.py
@@ -133,6 +133,38 @@ def select_candidate_document_ids(
     return tuple(selected)
 
 
+def build_document_local_candidate_pool(
+    candidate_document_ids: Sequence[str],
+    *,
+    load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
+    max_chunks: int,
+) -> tuple[G0RetrievedChunk, ...]:
+    if max_chunks <= 0:
+        raise ValueError("max_chunks must be positive")
+
+    selected: list[G0RetrievedChunk] = []
+    seen_chunk_ids: set[str] = set()
+    for document_id in candidate_document_ids:
+        if len(selected) >= max_chunks:
+            break
+
+        for chunk in load_document_chunks(document_id):
+            if chunk.document_id != document_id:
+                raise RuntimeError(
+                    f"loader returned document_id {chunk.document_id!r}, "
+                    f"expected {document_id!r}"
+                )
+            if chunk.chunk_id in seen_chunk_ids:
+                continue
+
+            seen_chunk_ids.add(chunk.chunk_id)
+            selected.append(chunk)
+            if len(selected) >= max_chunks:
+                break
+
+    return tuple(selected)
+
+
 @dataclass(frozen=True)
 class G0RetrievalOutcome:
     results: tuple[G0RetrievedChunk, ...]

--- a/experiments/evals/eval_techqa_generation.py
+++ b/experiments/evals/eval_techqa_generation.py
@@ -213,6 +213,28 @@ def select_document_local_evidence(
     return tuple(selected)
 
 
+def assemble_selected_evidence_context(
+    selected_evidence: Sequence[G0RetrievedChunk],
+    *,
+    max_context_chunks: int,
+) -> tuple[G0RetrievedChunk, ...]:
+    if max_context_chunks <= 0:
+        raise ValueError("max_context_chunks must be positive")
+
+    context: list[G0RetrievedChunk] = []
+    seen_chunk_ids: set[str] = set()
+    for chunk in selected_evidence:
+        if chunk.chunk_id in seen_chunk_ids:
+            continue
+
+        seen_chunk_ids.add(chunk.chunk_id)
+        context.append(chunk)
+        if len(context) >= max_context_chunks:
+            break
+
+    return tuple(context)
+
+
 @dataclass(frozen=True)
 class G0RetrievalOutcome:
     results: tuple[G0RetrievedChunk, ...]

--- a/experiments/evals/eval_techqa_generation.py
+++ b/experiments/evals/eval_techqa_generation.py
@@ -165,6 +165,54 @@ def build_document_local_candidate_pool(
     return tuple(selected)
 
 
+def select_document_local_evidence(
+    question: str,
+    candidate_pool: Sequence[G0RetrievedChunk],
+    *,
+    reranker: Callable[..., Any],
+    limit: int,
+) -> tuple[G0RetrievedChunk, ...]:
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if not candidate_pool:
+        return ()
+
+    candidates_by_chunk_id: dict[str, G0RetrievedChunk] = {}
+    for chunk in candidate_pool:
+        if chunk.chunk_id in candidates_by_chunk_id:
+            raise RuntimeError(f"duplicate candidate chunk_id {chunk.chunk_id!r}")
+        candidates_by_chunk_id[chunk.chunk_id] = chunk
+
+    candidates = tuple(
+        RerankCandidate(
+            chunk_id=chunk.chunk_id,
+            document_id=chunk.document_id,
+            content=chunk.content,
+        )
+        for chunk in candidate_pool
+    )
+    rerank_result = reranker(question.rstrip(), candidates)
+
+    selected: list[G0RetrievedChunk] = []
+    seen_reranked_chunk_ids: set[str] = set()
+    for reranked in rerank_result.results:
+        chunk_id = reranked.chunk_id
+        if chunk_id in seen_reranked_chunk_ids:
+            raise RuntimeError(f"duplicate reranked chunk_id {chunk_id!r}")
+        seen_reranked_chunk_ids.add(chunk_id)
+
+        source = candidates_by_chunk_id.get(chunk_id)
+        if source is None:
+            raise RuntimeError(
+                f"reranker returned chunk_id {chunk_id!r} outside candidate pool"
+            )
+        selected.append(source)
+        if len(selected) >= limit:
+            break
+
+    return tuple(selected)
+
+
 @dataclass(frozen=True)
 class G0RetrievalOutcome:
     results: tuple[G0RetrievedChunk, ...]

--- a/experiments/evals/eval_techqa_generation.py
+++ b/experiments/evals/eval_techqa_generation.py
@@ -111,6 +111,27 @@ class G0RetrievedChunk:
     distance: float
 
 
+@dataclass(frozen=True)
+class DiagnosticStageInvocations:
+    dense_search: int
+    document_chunk_loader: int
+    evidence_reranker: int
+    generation: int
+    judge: int
+
+
+@dataclass(frozen=True)
+class DocumentLocalEvidenceDiagnostic:
+    question_id: str
+    question: str
+    ranked_chunks: tuple[G0RetrievedChunk, ...]
+    candidate_document_ids: tuple[str, ...]
+    candidate_pool: tuple[G0RetrievedChunk, ...]
+    selected_evidence: tuple[G0RetrievedChunk, ...]
+    final_context: tuple[G0RetrievedChunk, ...]
+    stage_invocations: DiagnosticStageInvocations
+
+
 def select_candidate_document_ids(
     ranked_chunks: Sequence[G0RetrievedChunk],
     *,
@@ -233,6 +254,82 @@ def assemble_selected_evidence_context(
             break
 
     return tuple(context)
+
+
+def run_document_local_evidence_diagnostic(
+    question_id: str,
+    question: str,
+    ranked_chunks: Sequence[G0RetrievedChunk],
+    *,
+    candidate_document_limit: int,
+    load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
+    candidate_pool_max_chunks: int,
+    reranker: Callable[..., Any],
+    evidence_limit: int,
+    max_context_chunks: int,
+) -> DocumentLocalEvidenceDiagnostic:
+    if any(
+        limit <= 0
+        for limit in (
+            candidate_document_limit,
+            candidate_pool_max_chunks,
+            evidence_limit,
+            max_context_chunks,
+        )
+    ):
+        raise ValueError("all diagnostic limits must be positive")
+
+    ranked = tuple(ranked_chunks)
+    candidate_document_ids = select_candidate_document_ids(
+        ranked,
+        limit=candidate_document_limit,
+    )
+    document_chunk_loader_invocations = 0
+
+    def tracked_loader(document_id: str) -> Sequence[G0RetrievedChunk]:
+        nonlocal document_chunk_loader_invocations
+        document_chunk_loader_invocations += 1
+        return load_document_chunks(document_id)
+
+    candidate_pool = build_document_local_candidate_pool(
+        candidate_document_ids,
+        load_document_chunks=tracked_loader,
+        max_chunks=candidate_pool_max_chunks,
+    )
+    evidence_reranker_invocations = 0
+
+    def tracked_reranker(*args: Any) -> Any:
+        nonlocal evidence_reranker_invocations
+        evidence_reranker_invocations += 1
+        return reranker(*args)
+
+    selected_evidence = select_document_local_evidence(
+        question,
+        candidate_pool,
+        reranker=tracked_reranker,
+        limit=evidence_limit,
+    )
+    final_context = assemble_selected_evidence_context(
+        selected_evidence,
+        max_context_chunks=max_context_chunks,
+    )
+
+    return DocumentLocalEvidenceDiagnostic(
+        question_id=question_id,
+        question=question,
+        ranked_chunks=ranked,
+        candidate_document_ids=candidate_document_ids,
+        candidate_pool=candidate_pool,
+        selected_evidence=selected_evidence,
+        final_context=final_context,
+        stage_invocations=DiagnosticStageInvocations(
+            dense_search=0,
+            document_chunk_loader=document_chunk_loader_invocations,
+            evidence_reranker=evidence_reranker_invocations,
+            generation=0,
+            judge=0,
+        ),
+    )
 
 
 @dataclass(frozen=True)

--- a/experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1.json
+++ b/experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1.json
@@ -1,0 +1,161 @@
+{
+  "experiment_id": "techqa_g1_blinded_evidence_sufficiency_30case_v1",
+  "created_at": "2026-09-04",
+  "artifact_state": "PREREGISTRATION_BEFORE_EXECUTION",
+  "dataset": {
+    "generation_loader": "load_frozen_techqa_generation_cases",
+    "generation_repository": "nvidia/TechQA-RAG-Eval",
+    "generation_revision": "0b5bbc84b7f07d6d09d063130e90b716d8d4a32a",
+    "generation_record_count": 910,
+    "retrieval_trace": "experiments/evals/reports/e0_dense/train_results.jsonl",
+    "corpus_repository": "bowang0911/TechQA-RAG-Eval",
+    "corpus_revision": "68323f8f191fd5df93e2b2673d79a5da3a805638",
+    "offline_environment": {
+      "HF_HUB_OFFLINE": "1",
+      "HF_DATASETS_OFFLINE": "1"
+    }
+  },
+  "sample_seed": "techqa-g1-evidence-sufficiency-v1",
+  "sample_size": 30,
+  "excluded_case_ids": [
+    "TRAIN_Q055", "TRAIN_Q102", "TRAIN_Q130", "TRAIN_Q294",
+    "TRAIN_Q299", "TRAIN_Q335", "TRAIN_Q418", "TRAIN_Q427",
+    "TRAIN_Q447", "TRAIN_Q485", "TRAIN_Q542", "TRAIN_Q572"
+  ],
+  "eligibility_rule": {
+    "split": "train",
+    "answerable": true,
+    "e0_trace_required": true,
+    "formal_relevant_document_count": 1,
+    "stage2_responsibility_boundary": "After first-occurrence collapse of E0 raw_document_ids, the sole formal relevant document must be among the first five unique documents."
+  },
+  "eligible_universe_count": 273,
+  "selection_algorithm": "For every eligible question_id, compute sha256(sample_seed + ':' + question_id).hexdigest(); sort ascending by (hash, question_id); select the first 30. No shuffle, manual selection, outcome-based selection, or replacement is permitted.",
+  "selected_case_ids": [
+    "TRAIN_Q458", "TRAIN_Q400", "TRAIN_Q118", "TRAIN_Q346", "TRAIN_Q471",
+    "TRAIN_Q198", "TRAIN_Q227", "TRAIN_Q129", "TRAIN_Q001", "TRAIN_Q018",
+    "TRAIN_Q072", "TRAIN_Q415", "TRAIN_Q492", "TRAIN_Q519", "TRAIN_Q345",
+    "TRAIN_Q589", "TRAIN_Q490", "TRAIN_Q547", "TRAIN_Q161", "TRAIN_Q233",
+    "TRAIN_Q583", "TRAIN_Q145", "TRAIN_Q297", "TRAIN_Q231", "TRAIN_Q390",
+    "TRAIN_Q182", "TRAIN_Q243", "TRAIN_Q224", "TRAIN_Q541", "TRAIN_Q091"
+  ],
+  "capacity_preflight": {
+    "performed_after_sample_freeze": true,
+    "source_path": "historical E0 raw_document_ids -> first five unique candidate documents -> frozen corpus -> build_techqa_chunks",
+    "candidate_document_limit": 5,
+    "candidate_pool_max_chunks": 500,
+    "percentile_method": "linear interpolation over sorted n=30 values, position=(n-1)*p",
+    "chunk_count_summary": {
+      "min": 7,
+      "p50": 31.0,
+      "p90": 56.2,
+      "p95": 61.3,
+      "max": 72
+    },
+    "pool_overflow_case_ids": [],
+    "capacity_blocker": "none",
+    "paid_experiment_authorized": "no_pending_preregistration_review",
+    "per_case": [
+      {"question_id":"TRAIN_Q458","candidate_pool_chunk_count":49,"candidate_pool_content_chars":32014},
+      {"question_id":"TRAIN_Q400","candidate_pool_chunk_count":28,"candidate_pool_content_chars":16817},
+      {"question_id":"TRAIN_Q118","candidate_pool_chunk_count":72,"candidate_pool_content_chars":46319},
+      {"question_id":"TRAIN_Q346","candidate_pool_chunk_count":27,"candidate_pool_content_chars":17351},
+      {"question_id":"TRAIN_Q471","candidate_pool_chunk_count":32,"candidate_pool_content_chars":20370},
+      {"question_id":"TRAIN_Q198","candidate_pool_chunk_count":37,"candidate_pool_content_chars":21952},
+      {"question_id":"TRAIN_Q227","candidate_pool_chunk_count":33,"candidate_pool_content_chars":20495},
+      {"question_id":"TRAIN_Q129","candidate_pool_chunk_count":7,"candidate_pool_content_chars":3899},
+      {"question_id":"TRAIN_Q001","candidate_pool_chunk_count":26,"candidate_pool_content_chars":15315},
+      {"question_id":"TRAIN_Q018","candidate_pool_chunk_count":32,"candidate_pool_content_chars":20006},
+      {"question_id":"TRAIN_Q072","candidate_pool_chunk_count":32,"candidate_pool_content_chars":18028},
+      {"question_id":"TRAIN_Q415","candidate_pool_chunk_count":21,"candidate_pool_content_chars":12633},
+      {"question_id":"TRAIN_Q492","candidate_pool_chunk_count":34,"candidate_pool_content_chars":21505},
+      {"question_id":"TRAIN_Q519","candidate_pool_chunk_count":50,"candidate_pool_content_chars":29111},
+      {"question_id":"TRAIN_Q345","candidate_pool_chunk_count":64,"candidate_pool_content_chars":38434},
+      {"question_id":"TRAIN_Q589","candidate_pool_chunk_count":58,"candidate_pool_content_chars":40438},
+      {"question_id":"TRAIN_Q490","candidate_pool_chunk_count":20,"candidate_pool_content_chars":11812},
+      {"question_id":"TRAIN_Q547","candidate_pool_chunk_count":17,"candidate_pool_content_chars":10118},
+      {"question_id":"TRAIN_Q161","candidate_pool_chunk_count":34,"candidate_pool_content_chars":22139},
+      {"question_id":"TRAIN_Q233","candidate_pool_chunk_count":30,"candidate_pool_content_chars":18273},
+      {"question_id":"TRAIN_Q583","candidate_pool_chunk_count":56,"candidate_pool_content_chars":35020},
+      {"question_id":"TRAIN_Q145","candidate_pool_chunk_count":39,"candidate_pool_content_chars":24143},
+      {"question_id":"TRAIN_Q297","candidate_pool_chunk_count":15,"candidate_pool_content_chars":8265},
+      {"question_id":"TRAIN_Q231","candidate_pool_chunk_count":27,"candidate_pool_content_chars":18264},
+      {"question_id":"TRAIN_Q390","candidate_pool_chunk_count":20,"candidate_pool_content_chars":12125},
+      {"question_id":"TRAIN_Q182","candidate_pool_chunk_count":26,"candidate_pool_content_chars":15220},
+      {"question_id":"TRAIN_Q243","candidate_pool_chunk_count":26,"candidate_pool_content_chars":15871},
+      {"question_id":"TRAIN_Q224","candidate_pool_chunk_count":35,"candidate_pool_content_chars":20448},
+      {"question_id":"TRAIN_Q541","candidate_pool_chunk_count":11,"candidate_pool_content_chars":7400},
+      {"question_id":"TRAIN_Q091","candidate_pool_chunk_count":17,"candidate_pool_content_chars":9790}
+    ]
+  },
+  "method_contracts": {
+    "G0": {
+      "path": "historical E0 Dense Top100 -> one qwen3-rerank -> rerank Top3 -> context Top3",
+      "shared_rerank_with_E1": true,
+      "forward_siblings": "forbidden",
+      "rescue": "forbidden"
+    },
+    "E1": {
+      "source_function": "retrieve_g0_e1_context",
+      "source_file": "experiments/evals/eval_techqa_generation.py",
+      "source_commit": "dc5fb07b584b993516e77455b0b4efb22736b48a",
+      "path": "historical E1 implementation: Dense Top100 -> same shared qwen3-rerank result as G0 -> reranked Top3 anchors plus Dense Top1 rescue -> up to three forward siblings per anchor -> dedupe -> max16 context"
+    },
+    "G1": {
+      "path": "historical E0 ranking -> first five unique candidate documents -> frozen corpus full document-local chunks -> one merged qwen3-rerank -> Top16 selected evidence -> max16 context",
+      "candidate_document_limit": 5,
+      "candidate_pool_max_chunks": 500,
+      "evidence_limit": 16,
+      "max_context_chunks": 16
+    }
+  },
+  "provider_call_budget": {
+    "max_cases": 30,
+    "g0_e1_shared_top100_rerank_calls_per_case": 1,
+    "g1_merged_rerank_calls_per_case": 1,
+    "max_rerank_calls": 60,
+    "max_embedding_calls": 0,
+    "max_generation_calls": 0,
+    "max_judge_calls": 0,
+    "forbidden": ["per-document rerank", "second-pass rerank", "provider retry", "query rewrite", "alternate reranker"]
+  },
+  "gold_claim_rubric": {
+    "authoritative_source": "frozen TechQA generation gold_answer",
+    "procedure": "Freeze material claims from question and gold_answer before viewing any method context.",
+    "claim_support_labels": ["EXPLICIT_SUPPORT", "COMPOSABLE_SUPPORT", "INFERENCE_ONLY", "ABSENT"],
+    "covered_labels": ["EXPLICIT_SUPPORT", "COMPOSABLE_SUPPORT"],
+    "sufficiency_labels": {
+      "COMPLETE": "all material claims covered",
+      "PARTIAL": "at least one, but not all, material claims covered",
+      "INSUFFICIENT": "central answer fact not supported",
+      "UNRESOLVED": "cannot be reliably judged"
+    },
+    "claim_coverage": "covered_claim_count / material_claim_count",
+    "forbidden_metrics": ["gold chunk recall", "gold chunk MRR"]
+  },
+  "blinding_protocol": {
+    "packet_fields": ["question_id", "question", "gold_answer", "material_claims", "Context A", "Context B", "Context C"],
+    "packet_forbidden_fields": ["G0", "E1", "G1", "rerank scores", "method provenance", "historical outcomes"],
+    "mapping_rule": "Compute sha256('techqa-g1-blind-v1:' + question_id).digest(); apply Fisher-Yates to [G0,E1,G1] for i=2 then i=1 using digest[2-i] modulo (i+1); map resulting order to A,B,C. Store mapping separately and reveal only after all A/B/C judgments are complete."
+  },
+  "primary_metrics": {
+    "primary_comparison": "G1_vs_E1",
+    "ordinal_scores": {"COMPLETE": 2, "PARTIAL": 1, "INSUFFICIENT": 0},
+    "unresolved_policy": "UNRESOLVED is unscored and requires manual review.",
+    "per_method": ["complete_count", "insufficient_count", "claim_coverage"],
+    "pairwise": ["G1_vs_E1_wins", "G1_vs_E1_ties", "G1_vs_E1_losses"]
+  },
+  "catastrophic_regression_definition": "E1=COMPLETE and G1=INSUFFICIENT; record count and case IDs.",
+  "go_no_go_rule": {
+    "GO_TO_GENERATION_DESIGN": "yes only when all 30 cases complete, unresolved_count=0, provider/capacity contract remains unchanged, G1_complete_count>=E1_complete_count, G1_insufficient_count<=E1_insufficient_count, G1_vs_E1_wins>=G1_vs_E1_losses, and catastrophic_regression_count=0; otherwise no.",
+    "interpretation_limit": "A yes only means G1 evidence context was not worse than E1 on these blinded Stage2 cases; it does not establish RAG-accuracy improvement, production readiness, or statistical significance."
+  },
+  "historical_forensic_cases_in_gate": false,
+  "forbidden_adaptations": [
+    "no case replacement", "no resampling", "no D change", "no Top16 change",
+    "no adjacency addition", "no reranker-model change", "no prompt/instruction tuning",
+    "no query rewrite", "no per-document reranking", "no generation", "no judge",
+    "no outcome-based exclusions"
+  ],
+  "experiment_results": "intentionally absent"
+}

--- a/experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json
+++ b/experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json
@@ -1,0 +1,174 @@
+{
+  "experiment_id": "techqa_g1_blinded_evidence_sufficiency_30case_v1",
+  "preregistration_revision": "1.1",
+  "artifact_state": "PREREGISTRATION_HARDENING_BEFORE_EXECUTION",
+  "supersedes": "experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1.json",
+  "supersedes_commit": "272a1f8e6167524199dc883765ef67073679d93b",
+  "revision_reason": "pre-result contract hardening before any 30-case provider execution",
+  "paid_30case_provider_calls_before_revision": 0,
+  "dataset": {
+    "generation_loader": "load_frozen_techqa_generation_cases",
+    "generation_repository": "nvidia/TechQA-RAG-Eval",
+    "generation_revision": "0b5bbc84b7f07d6d09d063130e90b716d8d4a32a",
+    "generation_record_count": 910,
+    "retrieval_trace": "experiments/evals/reports/e0_dense/train_results.jsonl",
+    "corpus_repository": "bowang0911/TechQA-RAG-Eval",
+    "corpus_revision": "68323f8f191fd5df93e2b2673d79a5da3a805638"
+  },
+  "sample_seed": "techqa-g1-evidence-sufficiency-v1",
+  "sample_size": 30,
+  "selected_case_ids": [
+    "TRAIN_Q458", "TRAIN_Q400", "TRAIN_Q118", "TRAIN_Q346", "TRAIN_Q471",
+    "TRAIN_Q198", "TRAIN_Q227", "TRAIN_Q129", "TRAIN_Q001", "TRAIN_Q018",
+    "TRAIN_Q072", "TRAIN_Q415", "TRAIN_Q492", "TRAIN_Q519", "TRAIN_Q345",
+    "TRAIN_Q589", "TRAIN_Q490", "TRAIN_Q547", "TRAIN_Q161", "TRAIN_Q233",
+    "TRAIN_Q583", "TRAIN_Q145", "TRAIN_Q297", "TRAIN_Q231", "TRAIN_Q390",
+    "TRAIN_Q182", "TRAIN_Q243", "TRAIN_Q224", "TRAIN_Q541", "TRAIN_Q091"
+  ],
+  "selection_algorithm": "For every eligible question_id, compute sha256(sample_seed + ':' + question_id).hexdigest(); sort ascending by (hash, question_id); select the first 30. No shuffle, manual selection, outcome-based selection, or replacement is permitted.",
+  "eligibility_rule": {
+    "split": "train",
+    "answerable": true,
+    "e0_trace_required": true,
+    "formal_relevant_document_count": 1,
+    "stage2_responsibility_boundary": "After first-occurrence collapse of E0 raw_document_ids, the sole formal relevant document must be among the first five unique documents."
+  },
+  "historical_exclusion_set_size": 12,
+  "formal_relevant_top5_before_exclusion": 276,
+  "historical_cases_removed_from_eligible_universe": 3,
+  "eligible_after_exclusion": 273,
+  "count_identity": "276 - 3 = 273. The exclusion list has 12 cases, but only three intersect the current Stage2 eligible universe.",
+  "capacity_preflight": {
+    "inherited_from_v1": true,
+    "candidate_document_limit": 5,
+    "candidate_pool_max_chunks": 500,
+    "evidence_limit": 16,
+    "max_context_chunks": 16,
+    "frozen_sample_pool_max_chunks": 72,
+    "capacity_blocker": "none",
+    "no_resampling_after_capacity_check": true
+  },
+  "method_contracts": {
+    "G0": {
+      "path": "historical E0 Dense Top100 -> one shared real qwen3-rerank -> first 3 results -> Top3 context",
+      "forward_siblings": "forbidden",
+      "rescue": "forbidden"
+    },
+    "E1": {
+      "source_function": "retrieve_g0_e1_context",
+      "source_file": "experiments/evals/eval_techqa_generation.py",
+      "source_commit": "dc5fb07b584b993516e77455b0b4efb22736b48a",
+      "semantics": "shared rerank Top3 anchors plus historical E0 Dense rank1 rescue; expand each unique anchor document as anchor plus up to three forward siblings; dedupe chunk IDs; max context chunks=16.",
+      "required_dependency_injection": {
+        "historical_e0_dense_searcher": "Replay exact frozen E0 Top100 ordering; live Dense is forbidden.",
+        "replay_reranker": "Return the already obtained shared G0/E1 rerank result; a second provider call is forbidden.",
+        "offline_forward_sibling_loader": "Read +1, +2, +3 siblings from frozen TechQA corpus through deterministic chunk building; default Chroma sibling loading is forbidden."
+      },
+      "preflight_required_before_paid_execution": [
+        "e1_default_dense_searcher_used=no",
+        "e1_default_chroma_sibling_loader_used=no",
+        "e1_second_provider_rerank_call=no"
+      ]
+    },
+    "G1": {
+      "path": "historical E0 ranking -> first 5 unique candidate documents -> frozen full document-local chunks -> one merged qwen3-rerank -> Top16 -> max16 context",
+      "candidate_document_limit": 5,
+      "candidate_pool_max_chunks": 500,
+      "evidence_limit": 16,
+      "max_context_chunks": 16
+    }
+  },
+  "rerank_contract": {
+    "model": "qwen3-rerank",
+    "instruction": "Rank the candidate passages by relevance to resolving the technical support query.",
+    "same_instruction_all_methods": true,
+    "forbidden": ["prompt tuning", "method-specific instruction", "query rewrite", "alternate reranker", "per-document reranking", "second-pass rerank"]
+  },
+  "provider_call_budget": {
+    "max_cases": 30,
+    "g0_e1_shared_top100_rerank_calls_per_case": 1,
+    "g1_merged_rerank_calls_per_case": 1,
+    "planned_max_real_rerank_calls": 60,
+    "max_embedding_calls": 0,
+    "max_generation_calls": 0,
+    "max_judge_calls": 0,
+    "provider_failure_policy": "Any real provider failure stops the run. Do not retry, change model, reduce candidates, remove or replace a case, or continue remaining cases. Preserve partial provenance for separate review."
+  },
+  "gold_claim_rubric": {
+    "authoritative_source": "frozen TechQA generation gold_answer",
+    "claim_decomposition_order": [
+      "Read only question and gold_answer.",
+      "Freeze material claims from gold_answer before opening any A/B/C context.",
+      "Review blinded contexts without revising the decomposition."
+    ],
+    "question_role": "Question may clarify entity and context only; facts absent from gold_answer are not scored claims.",
+    "identifier_preservation": ["CVE", "version", "score", "command", "negation", "condition"],
+    "claim_decomposition_completed_before_context_review": "required=yes",
+    "claim_support_labels": ["EXPLICIT_SUPPORT", "COMPOSABLE_SUPPORT", "INFERENCE_ONLY", "ABSENT"],
+    "covered_labels": ["EXPLICIT_SUPPORT", "COMPOSABLE_SUPPORT"],
+    "all_material_claims_equal_weight": true,
+    "posthoc_claim_importance_weighting": "forbidden",
+    "sufficiency_labels": {
+      "COMPLETE": "covered_claim_count == material_claim_count and material_claim_count > 0",
+      "PARTIAL": "0 < covered_claim_count < material_claim_count",
+      "INSUFFICIENT": "covered_claim_count == 0 and material_claim_count > 0",
+      "UNRESOLVED": "claim decomposition or evidence support cannot be reliably judged"
+    },
+    "case_claim_coverage": "covered_claim_count / material_claim_count",
+    "aggregate_claim_coverage": "method_macro_claim_coverage = mean(case_claim_coverage for all 30 cases)",
+    "descriptive_only_totals": ["total_covered_claims", "total_material_claims"],
+    "forbidden_metrics": ["gold chunk recall", "gold chunk MRR"]
+  },
+  "blinding_protocol": {
+    "blinding_type": "METHOD_LABEL_BLINDED",
+    "BLIND_SEED": "techqa-g1-blind-v1",
+    "permutation_table": {
+      "0": ["G0", "E1", "G1"],
+      "1": ["G0", "G1", "E1"],
+      "2": ["E1", "G0", "G1"],
+      "3": ["E1", "G1", "G0"],
+      "4": ["G1", "G0", "E1"],
+      "5": ["G1", "E1", "G0"]
+    },
+    "permutation_algorithm": "digest = sha256('techqa-g1-blind-v1:' + question_id).hexdigest(); permutation_index = int(digest, 16) % 6; [A, B, C] = PERMUTATION_TABLE[permutation_index].",
+    "packet_fields": ["question_id", "question", "gold_answer", "material_claims", "Context A", "Context B", "Context C"],
+    "context_item_labels": "A1, A2, ...; B1, B2, ...; C1, C2, ...",
+    "packet_forbidden_fields": ["G0", "E1", "G1", "rerank scores", "rerank ranks", "method name", "source implementation", "forward sibling", "document-local", "provider request id", "raw chunk_id", "raw document_id"],
+    "mapping_separate": true,
+    "unblind_rule": "Reveal method and provenance mapping only after all claim-support and sufficiency judgments are complete.",
+    "structural_leakage_limitation": "Context length and structure can still suggest a method type; this is not fully or double blinded."
+  },
+  "review_isolation": {
+    "step_1": "Packet builder creates blinded packets and separate sealed method/provenance mapping.",
+    "step_2": "Evidence reviewer reads only blinded packet and completes all judgments before unblinding.",
+    "reviewer_had_method_mapping": "required=no",
+    "codex_reviewer_requirement": "Use a fresh reviewer context, session, or subagent that receives only the blinded packet and no method mapping or historical outcomes."
+  },
+  "primary_metrics_and_go_no_go": {
+    "primary_comparison": "G1_vs_E1",
+    "ordinal_scores": {"COMPLETE": 2, "PARTIAL": 1, "INSUFFICIENT": 0},
+    "unresolved_policy": "UNRESOLVED is unscored; any unresolved_count > 0 means GO_TO_GENERATION_DESIGN=no.",
+    "pairwise_rule": "G1>E1 is WIN; equal is TIE; G1<E1 is LOSS.",
+    "catastrophic_regression_definition": "E1=COMPLETE and G1=INSUFFICIENT.",
+    "go_requirements": ["all 30 cases complete", "unresolved_count=0", "provider/capacity contract unchanged", "G1_complete_count>=E1_complete_count", "G1_insufficient_count<=E1_insufficient_count", "G1_vs_E1_wins>=G1_vs_E1_losses", "catastrophic_regression_count=0"]
+  },
+  "interpretation_boundary": {
+    "experiment_scope": "CONDITIONAL_STAGE2_EVIDENCE_EXPERIMENT: formal relevant document already appears in E0 Top5.",
+    "permitted_conclusion": "Given Stage1 has placed the formal relevant document in Top5, G1 context sufficiency is at least not worse than E1.",
+    "full_rag_retrieval_improvement_claim": "forbidden",
+    "all_techqa_improvement_claim": "forbidden",
+    "production_accuracy_improvement_claim": "forbidden"
+  },
+  "historical_forensic_cases_in_gate": false,
+  "forbidden_adaptations": [
+    "no case replacement", "no resampling", "no D change", "no Top3 change", "no Top16 change",
+    "no adjacency addition", "no reranker-model change", "no prompt/instruction tuning", "no query rewrite",
+    "no per-document reranking", "no generation", "no judge", "no outcome-based exclusions"
+  ],
+  "permitted_v1_to_v1_1_changes": [
+    "count semantics clarification", "rubric disambiguation", "metric formula clarification",
+    "E1 dependency injection contract", "exact rerank instruction freeze", "exact blinding algorithm",
+    "reviewer isolation", "interpretation and failure-policy hardening"
+  ],
+  "experiment_results": "intentionally absent"
+}

--- a/experiments/evals/reports/g1_document_local/final_decision.md
+++ b/experiments/evals/reports/g1_document_local/final_decision.md
@@ -1,0 +1,296 @@
+# G1 Document-Local Evidence Sufficiency — Final Decision
+
+## Status
+
+**Official preregistered decision: NO_GO.**
+
+G1 materially improved aggregate evidence sufficiency over the E1 reference on the frozen 30-case experiment, but it triggered one preregistered catastrophic regression (`E1=COMPLETE` and `G1=INSUFFICIENT`). The gate is therefore not relaxed post hoc, and G1 does **not** replace E1 as the current reference context policy.
+
+This is not evidence that the document-local design is broadly worse than E1. It is a bounded deployment/evaluation decision: aggregate gains were strong, while one predeclared safety gate failed.
+
+## Experiment scope
+
+The authoritative preregistration is:
+
+- `evidence_sufficiency_30case_preregistration_v1_1.json`
+- experiment id: `techqa_g1_blinded_evidence_sufficiency_30case_v1`
+- sample size: 30 answerable `TRAIN_*` cases
+- deterministic sample seed: `techqa-g1-evidence-sufficiency-v1`
+- historical G0 12-case pilot excluded
+- no resampling or outcome-based case replacement
+- conditional Stage2 scope: the formal relevant TechQA document had to appear among the first five unique documents in the historical E0 ranking
+
+The experiment therefore evaluates **context evidence sufficiency after a bounded candidate-document admission condition**. It does not establish an all-TechQA retrieval uplift or a production accuracy improvement.
+
+## Compared methods
+
+### E1 reference
+
+```text
+historical E0 Dense Top100
+        ↓
+one shared qwen3-rerank
+        ↓
+Top3 rerank anchors
++ historical Dense rank1 rescue
+        ↓
+for each unique anchor document:
+anchor + up to 3 forward siblings
+        ↓
+deduplicate
+        ↓
+max 16 context chunks
+```
+
+### G1 candidate
+
+```text
+historical E0 ranking
+        ↓
+first 5 unique candidate documents
+        ↓
+full frozen document-local chunk expansion
+        ↓
+one merged qwen3-rerank
+        ↓
+Top16 evidence chunks
+        ↓
+max 16 context chunks
+```
+
+Frozen reranker contract:
+
+- model: `qwen3-rerank`
+- instruction: `Rank the candidate passages by relevance to resolving the technical support query.`
+- no query rewrite
+- no method-specific prompt
+- no per-document reranking
+- no second-pass rerank
+- no embedding, generation, or judge calls in the paid 30-case retrieval execution
+
+## Evidence review contract
+
+Gold-answer material claims were frozen before any blinded context review. The final claim freeze contained:
+
+- 30 cases
+- 65 material claims
+- 195 claim-context judgments across G0 / E1 / G1
+
+Claim support labels:
+
+- `EXPLICIT_SUPPORT`
+- `COMPOSABLE_SUPPORT`
+- `INFERENCE_ONLY`
+- `ABSENT`
+
+Only `EXPLICIT_SUPPORT` and `COMPOSABLE_SUPPORT` count as covered.
+
+Per-context sufficiency:
+
+- `COMPLETE`: every material claim covered
+- `PARTIAL`: at least one but not all claims covered
+- `INSUFFICIENT`: zero material claims covered
+- `UNRESOLVED`: evidence support cannot be judged reliably
+
+The primary aggregate coverage metric is the macro mean of per-case claim coverage, not a micro-weighted total over claims.
+
+Method identity remained blinded until all claim-support and sufficiency judgments were frozen.
+
+## Formal result
+
+| Metric | E1 | G1 | G1 - E1 |
+| --- | ---: | ---: | ---: |
+| COMPLETE | 24 / 30 | **28 / 30** | +4 cases |
+| PARTIAL | 1 / 30 | 1 / 30 | 0 |
+| INSUFFICIENT | 5 / 30 | **1 / 30** | -4 cases |
+| Macro claim coverage | 0.825000 | **0.955556** | **+0.130556** |
+
+Pairwise preregistered ordinal movement (`COMPLETE=2`, `PARTIAL=1`, `INSUFFICIENT=0`):
+
+- G1 wins: **6**
+- ties: **22**
+- losses: **2**
+
+Win cases:
+
+- `TRAIN_Q458`
+- `TRAIN_Q118`
+- `TRAIN_Q227`
+- `TRAIN_Q415`
+- `TRAIN_Q589`
+- `TRAIN_Q091`
+
+Loss cases:
+
+- `TRAIN_Q346`
+- `TRAIN_Q492`
+
+The preregistered catastrophic regression definition was:
+
+```text
+E1 = COMPLETE
+and
+G1 = INSUFFICIENT
+```
+
+Observed catastrophic regressions:
+
+- count: **1**
+- case: `TRAIN_Q346`
+
+Therefore the formal gate is:
+
+```text
+G1_complete_count >= E1_complete_count       PASS
+G1_insufficient_count <= E1_insufficient     PASS
+G1_wins >= G1_losses                          PASS
+catastrophic_regression_count == 0            FAIL
+-------------------------------------------------
+OFFICIAL DECISION                             NO_GO
+```
+
+## Claim-level transition audit
+
+A post-unblinding forensic pass examined all 65 frozen claims without changing the rubric or judgments.
+
+| Transition | Count |
+| --- | ---: |
+| E1 covered -> G1 covered | 57 |
+| E1 covered -> G1 not covered | 2 |
+| E1 not covered -> G1 covered | 6 |
+| E1 not covered -> G1 not covered | 0 |
+
+Net claim movement:
+
+- lost claims: 2
+- gained claims: 6
+- net gain: **+4**
+
+Gain attribution:
+
+- merged-rerank gain: 3 claims
+- document-local expansion gain: 2 claims
+- multi-chunk evidence gain: 1 claim
+
+The gains are therefore mixed rather than attributable to one single mechanism.
+
+## Regression forensics
+
+### `TRAIN_Q346`: candidate-document admission miss
+
+Frozen claim:
+
+> This defect is resolved in IBM Rational DOORS Version 9.4.0.1.
+
+E1 covered the claim explicitly. The decisive evidence came from:
+
+- document: `swg1PM50525.txt`
+- chunk: `swg1PM50525.txt_chunk_0`
+
+The decisive chunk was deep in the historical E0 chunk ranking (position 72, one-based), but E1's global reranker promoted it into the Top3 anchor set. G1 instead admitted only the first five unique documents from the historical E0 order before its merged document-local rerank. `swg1PM50525.txt` was not in that first-five document set, so the decisive chunk never entered G1's 27-chunk candidate pool.
+
+Root cause:
+
+```text
+CANDIDATE_DOCUMENT_MISS
+```
+
+The important diagnostic lesson is narrower than "Top5 is too small":
+
+> a weak first-stage document-order gate can permanently remove a tail chunk that a stronger global reranker would have rescued.
+
+The formal relevant-document eligibility rule and the generation evidence needed for a material claim are not guaranteed to be the same thing. This case therefore also reinforces the existing project distinction:
+
+```text
+document-level qrel hit != answer-bearing evidence hit
+```
+
+### `TRAIN_Q492`: continuity miss
+
+E1 was `COMPLETE` (3/3 claims); G1 was `PARTIAL` (2/3).
+
+For the missing claim, E1 retained evidence from:
+
+- `swg21972012.txt_chunk_1`
+- forward sibling `swg21972012.txt_chunk_2`
+
+G1 admitted the document and included both chunks in its 34-chunk document-local candidate pool, but the final Top16 retained chunk 1 while omitting the decisive sibling chunk 2. The exact merged-rerank rank of chunk 2 was not persisted; the preserved evidence establishes only that it was outside the final selected Top16.
+
+Root cause:
+
+```text
+CONTINUITY_MISS
+```
+
+## Are these systemic G1 defects?
+
+No repeated mechanism was found in the remaining frozen claim transitions:
+
+- candidate-document admission miss repeated elsewhere: **no**
+- continuity miss repeated elsewhere: **no**
+- candidate-chunk construction miss: 0
+- assembly miss after Top16 selection: 0
+- insufficient provenance: 0
+
+The two regressions therefore have different failure boundaries and were classified as **isolated regressions**, not evidence of one shared systemic reranker defect.
+
+This matters for the next decision: changing `first5 -> first10`, forcing a sibling rule, or adding case-specific rescue logic after inspecting Q346/Q492 would be high-risk TRAIN overfitting.
+
+## Final engineering decision
+
+**Keep E1 as the current reference. Keep G1 as an evaluated experimental candidate. Do not patch G1 on the already-inspected 30-case TRAIN set.**
+
+Supported conclusions:
+
+1. G1 materially improves aggregate evidence sufficiency on the frozen conditional 30-case experiment.
+2. G1 increases COMPLETE contexts from 24/30 to 28/30 and macro claim coverage from 0.825 to 0.9556.
+3. The preregistered replacement gate still fails because one E1-complete case becomes G1-insufficient.
+4. The two observed regressions have distinct, non-repeating mechanisms in this sample.
+5. The current evidence does not justify a Q346/Q492-targeted patch.
+
+Not supported:
+
+- claiming G1 replaced E1;
+- claiming a production generation-quality uplift;
+- claiming a full-TechQA retrieval improvement from this conditional Stage2 experiment;
+- relaxing the catastrophic-regression gate after seeing results;
+- tuning document count or continuity rules on these already-inspected cases and reporting that as fresh validation.
+
+## Next hypothesis boundary
+
+A future experiment may test a cleaner candidate-admission architecture on a **fresh preregistered held-out sample**, for example:
+
+```text
+wide chunk recall
+        ↓
+strong global rerank
+        ↓
+rerank-informed document admission
+        ↓
+document-local expansion
+        ↓
+merged evidence selection
+```
+
+A continuity safeguard should be treated as a separate causal variable unless independent evidence shows the two mechanisms should be coupled.
+
+The previous 30 G1 cases are now diagnostic/development evidence for any such next design and must not be presented as fresh validation of a patch derived from Q346 or Q492.
+
+## Artifact lineage
+
+Repository-frozen preregistration:
+
+- `experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json`
+- SHA256 recorded before paid execution: `05442933333b6b32c7988b8012feb6df33a97afd19494fc145dfa34d5cf1c898`
+
+Key local execution/review artifacts were kept outside Git; their recorded SHA256 digests are preserved here for audit lineage:
+
+- frozen claim decomposition v2: `cffe8033311df4c5482addbd53c48ce7d30c9469ccfe7da190ef086f0865b01f`
+- frozen blinded aggregation: `73ec0d79a32dd37667d51c3067778051c0ab4af04fea7e1c08bd50046dc82f7b`
+- blinded final manifest: `33f569f91dc9dad53d8346cd4caca21ba5efebf1e0772cf2ef0ea27614c1d157`
+- unblinded results: `6084ba65d24c19853403cb54067139e2a0a0176b4bbf885f6e7fa72905e4f2a1`
+- unblinded summary: `a005af6f3873ba2269b11e8c13572bd6e3ed1ece389c5c490cb7e772a3dba9a3`
+- 65-claim transition table: `555b21c0ee081431fcc4aaa6f9a179ed7de96f0f1ffed5cfc0d599033c05ea07`
+- claim-transition forensics summary: `79f8cd6019430c2c58a2d8a8232435e2757ebf6525aea0cfe60c1529bd7e7f92`
+
+Raw provider packets, reviewer packets, and scratch execution artifacts are intentionally not reconstructed from these digests or committed as if they were repository-native results. This report records the frozen decision and audit lineage; it does not fabricate missing raw artifacts.

--- a/experiments/evals/reports/g1_document_local/rerank_only_preregistration_v1.json
+++ b/experiments/evals/reports/g1_document_local/rerank_only_preregistration_v1.json
@@ -1,0 +1,154 @@
+{
+  "experiment_id": "g1_document_local_rerank_only_pilot_v1",
+  "created_at": "2026-09-03",
+  "artifact_state": "PREREGISTRATION_BEFORE_EXECUTION",
+  "experiment_question": "Given frozen Stage 1 candidate documents, can one query-relevance rerank over their complete merged chunks find document-local evidence more reliably than the prior chunk Top3 path?",
+  "scope_exclusions": [
+    "dense retrieval improvement",
+    "full RAG improvement",
+    "generation improvement",
+    "hallucination improvement",
+    "production-readiness"
+  ],
+  "source_stage1_artifact": {
+    "path": "experiments/evals/reports/e0_dense/train_results.jsonl",
+    "frozen_fields": [
+      "raw_chunk_ids",
+      "raw_document_ids"
+    ],
+    "candidate_document_construction": "first-occurrence collapse of raw_document_ids in historical order",
+    "live_retrieval_forbidden": true
+  },
+  "case_ids": [
+    "TRAIN_Q055",
+    "TRAIN_Q130",
+    "TRAIN_Q294",
+    "TRAIN_Q299",
+    "TRAIN_Q427",
+    "TRAIN_Q572"
+  ],
+  "dataset": {
+    "source": "frozen TechQA corpus",
+    "revision": "68323f8f191fd5df93e2b2673d79a5da3a805638",
+    "offline_environment": {
+      "HF_HUB_OFFLINE": "1",
+      "HF_DATASETS_OFFLINE": "1"
+    },
+    "document_loader": "load_frozen_techqa_documents",
+    "chunk_builder": "build_techqa_chunks",
+    "chroma_document_source_forbidden": true
+  },
+  "capacity_contract": {
+    "candidate_document_limit": 5,
+    "candidate_document_limit_interpretation": "A Stage 1 responsibility boundary, not a TRAIN-derived optimum: Stage 1 must place a relevant document in the top five candidates; misses outside that scope remain retrieval-layer failures.",
+    "candidate_pool_max_chunks": 500,
+    "candidate_pool_max_chunks_interpretation": "A provider and document-count safety ceiling, not a target pool size. Normal cases contain the complete chunks of the top five documents.",
+    "pool_overflow_policy": "POOL_OVERFLOW: do not call the reranker; do not truncate to the first 500 chunks; mark the case pilot STOP/NO-GO.",
+    "evidence_limit": 16,
+    "max_context_chunks": 16,
+    "evidence_boundary_interpretation": "The reranked Top16 is the evidence boundary. Matching the context cap avoids an additional free parameter."
+  },
+  "reranker_contract": {
+    "model": "qwen3-rerank",
+    "implementation": "experiments/evals/rerankers/qwen3_reranker.py",
+    "calls_per_case": 1,
+    "input": "complete rebuilt chunks from the top five Stage 1 candidate documents, merged into one pool",
+    "forbidden_patterns": [
+      "one rerank call per document",
+      "per-document rerank followed by merge",
+      "second rerank",
+      "live dense retrieval",
+      "BM25 or hybrid retrieval",
+      "embedding calls"
+    ]
+  },
+  "provider_capacity_contract": {
+    "max_documents_per_request": 500,
+    "max_tokens_per_document": 4000,
+    "max_tokens_per_request": 120000,
+    "execution_logging": [
+      "pool document count",
+      "pool content chars",
+      "provider usage.total_tokens when returned"
+    ],
+    "provider_size_error_policy": "PROVIDER_CAPACITY_FAILURE: stop; do not truncate chunks and retry; do not reduce candidate_document_limit and retry."
+  },
+  "provider_call_bounds": {
+    "max_rerank_calls": 6,
+    "max_embedding_calls": 0,
+    "max_generation_calls": 0,
+    "max_judge_calls": 0,
+    "provider_pricing_reference": "0.5 CNY / 1M input tokens (Beijing list price at preregistration time)",
+    "actual_cost_policy": "Calculate only after execution from returned provider usage."
+  },
+  "formal_metrics": {
+    "gold_level": "document identity only",
+    "per_case": [
+      "stage1_relevant_doc_in_top5",
+      "reranked_first_relevant_document_chunk_rank when Stage 1 contains the relevant document",
+      "relevant_document_present_in_top16 when Stage 1 contains the relevant document"
+    ],
+    "upstream_miss_policy": "NOT_EVALUATED_UPSTREAM_MISS when the Stage 1 relevant document is not in the top five.",
+    "forbidden_metrics": [
+      "gold chunk recall",
+      "gold chunk MRR"
+    ]
+  },
+  "forensic_targets": {
+    "TRAIN_Q055": {
+      "chunk_id": "swg21502037.txt_chunk_3",
+      "record": [
+        "target_candidate_pool_present",
+        "target_reranked_rank",
+        "target_top16"
+      ]
+    },
+    "TRAIN_Q572": {
+      "chunk_id": "swg21976896.txt_chunk_1",
+      "record": [
+        "target_candidate_pool_present",
+        "target_reranked_rank",
+        "target_top16"
+      ]
+    },
+    "TRAIN_Q299": {
+      "chunk_id": "swg21427178.txt_chunk_1",
+      "scope_policy": "FORENSIC_TARGET_OUTSIDE_PREREGISTERED_STAGE1_SCOPE when absent from the top-five pool; do not change candidate_document_limit and do not classify this as reranker failure."
+    },
+    "TRAIN_Q130": {
+      "scope_policy": "Formal relevant-document upstream absence is NOT_EVALUATED_UPSTREAM_MISS; do not require the merged reranker to recover an absent document."
+    }
+  },
+  "success_gate": {
+    "primary": "For every case with stage1_relevant_doc_in_top5=yes, report the paired first relevant-document chunk rank and relevant_document_present_in_top16. A relevant_document_present_in_top16=no is DOCUMENT_LEVEL_COLLAPSE.",
+    "mechanism_sentinels": {
+      "required": [
+        "TRAIN_Q055 target_top16=yes",
+        "TRAIN_Q572 target_top16=yes"
+      ],
+      "pass_condition": "Both required forensic targets are in Top16."
+    }
+  },
+  "go_no_go_rule": {
+    "GO_TO_GENERATION_DESIGN": "yes only if all provider calls complete, no pool overflow or provider-capacity failure occurs, the mechanism sentinel gate passes, and DOCUMENT_LEVEL_COLLAPSE=no.",
+    "DOCUMENT_LEVEL_COLLAPSE": "yes if any Stage 1-eligible case has relevant_document_present_in_top16=no.",
+    "otherwise": "GO_TO_GENERATION_DESIGN=no; analyze rerank/evidence selection before generation design."
+  },
+  "non_gates": [
+    "generation correctness",
+    "faithfulness",
+    "abstention",
+    "hallucination",
+    "TRAIN_Q299 forensic target Top16",
+    "TRAIN_Q130 recovery",
+    "latency improvement"
+  ],
+  "forbidden_adaptations": [
+    "truncate chunks after pool overflow",
+    "reduce candidate_document_limit after a size failure",
+    "retry with a smaller pool",
+    "alter the six case IDs after observing results",
+    "alter frozen budgets after observing results",
+    "run generation or judging during this pilot"
+  ]
+}

--- a/tests/test_generation_eval_runner.py
+++ b/tests/test_generation_eval_runner.py
@@ -22,6 +22,16 @@ def _candidate_document_selector():
     return selector
 
 
+def _document_local_pool_builder():
+    builder = getattr(
+        generation_eval,
+        "build_document_local_candidate_pool",
+        None,
+    )
+    assert builder is not None, "build_document_local_candidate_pool is not implemented"
+    return builder
+
+
 def _retrieved_chunk(
     chunk_id: str,
     document_id: str,
@@ -206,6 +216,119 @@ def test_candidate_document_selection_requires_positive_limit(limit):
 
     with pytest.raises(ValueError):
         selector((), limit=limit)
+
+
+def test_document_local_candidate_pool_preserves_document_and_loader_order():
+    builder = _document_local_pool_builder()
+    chunks_by_document = {
+        "B": (
+            _retrieved_chunk("B_chunk_4", "B", 4, 0.20),
+            _retrieved_chunk("B_chunk_1", "B", 1, 0.22),
+            _retrieved_chunk("B_chunk_3", "B", 3, 0.25),
+        ),
+        "A": (
+            _retrieved_chunk("A_chunk_5", "A", 5, 0.10),
+            _retrieved_chunk("A_chunk_2", "A", 2, 0.12),
+        ),
+    }
+
+    pool = builder(
+        ("B", "A"),
+        load_document_chunks=chunks_by_document.__getitem__,
+        max_chunks=5,
+    )
+
+    assert tuple(chunk.chunk_id for chunk in pool) == (
+        "B_chunk_4",
+        "B_chunk_1",
+        "B_chunk_3",
+        "A_chunk_5",
+        "A_chunk_2",
+    )
+
+
+def test_document_local_candidate_pool_deduplicates_chunk_ids_globally():
+    builder = _document_local_pool_builder()
+    chunks_by_document = {
+        "A": (
+            _retrieved_chunk("A_chunk_1", "A", 1, 0.10),
+            _retrieved_chunk("A_chunk_1", "A", 1, 0.10),
+            _retrieved_chunk("A_chunk_2", "A", 2, 0.12),
+        ),
+        "B": (_retrieved_chunk("B_chunk_1", "B", 1, 0.20),),
+    }
+
+    pool = builder(
+        ("A", "B"),
+        load_document_chunks=chunks_by_document.__getitem__,
+        max_chunks=4,
+    )
+
+    assert tuple(chunk.chunk_id for chunk in pool) == (
+        "A_chunk_1",
+        "A_chunk_2",
+        "B_chunk_1",
+    )
+
+
+def test_document_local_candidate_pool_stops_at_total_budget():
+    builder = _document_local_pool_builder()
+    calls: list[str] = []
+    chunks_by_document = {
+        "A": (
+            _retrieved_chunk("A_chunk_1", "A", 1, 0.10),
+            _retrieved_chunk("A_chunk_2", "A", 2, 0.12),
+        ),
+        "B": (
+            _retrieved_chunk("B_chunk_1", "B", 1, 0.20),
+            _retrieved_chunk("B_chunk_2", "B", 2, 0.25),
+        ),
+        "C": (_retrieved_chunk("C_chunk_1", "C", 1, 0.30),),
+    }
+
+    def load_document_chunks(document_id: str):
+        calls.append(document_id)
+        return chunks_by_document[document_id]
+
+    pool = builder(
+        ("A", "B", "C"),
+        load_document_chunks=load_document_chunks,
+        max_chunks=3,
+    )
+
+    assert tuple(chunk.chunk_id for chunk in pool) == (
+        "A_chunk_1",
+        "A_chunk_2",
+        "B_chunk_1",
+    )
+    assert calls == ["A", "B"]
+
+
+def test_document_local_candidate_pool_rejects_wrong_document_membership():
+    builder = _document_local_pool_builder()
+    chunks_by_document = {
+        "A": (_retrieved_chunk("shared_chunk", "A", 1, 0.10),),
+        "B": (_retrieved_chunk("shared_chunk", "A", 1, 0.10),),
+    }
+
+    with pytest.raises(RuntimeError, match="document_id"):
+        builder(
+            ("A", "B"),
+            load_document_chunks=chunks_by_document.__getitem__,
+            max_chunks=2,
+        )
+
+
+@pytest.mark.parametrize("max_chunks", [0, -1])
+def test_document_local_candidate_pool_requires_positive_budget(max_chunks):
+    builder = _document_local_pool_builder()
+
+    with pytest.raises(ValueError):
+        builder(
+            (),
+            load_document_chunks=lambda _: (),
+            max_chunks=max_chunks,
+        )
 
 
 def test_default_single_case_evaluator_uses_frozen_g0_retriever(monkeypatch):

--- a/tests/test_generation_eval_runner.py
+++ b/tests/test_generation_eval_runner.py
@@ -57,6 +57,16 @@ def _selected_evidence_context_assembler():
     return assembler
 
 
+def _document_local_diagnostic_runner():
+    runner = getattr(
+        generation_eval,
+        "run_document_local_evidence_diagnostic",
+        None,
+    )
+    assert runner is not None, "run_document_local_evidence_diagnostic is not implemented"
+    return runner
+
+
 def _retrieved_chunk(
     chunk_id: str,
     document_id: str,
@@ -576,6 +586,214 @@ def test_selected_evidence_context_requires_positive_budget(max_context_chunks):
 
     with pytest.raises(ValueError):
         assembler((), max_context_chunks=max_context_chunks)
+
+
+def test_document_local_diagnostic_records_full_four_stage_provenance():
+    runner = _document_local_diagnostic_runner()
+    ranked_chunks = (
+        _retrieved_chunk("A_chunk_5", "A", 5, 0.10),
+        _retrieved_chunk("A_chunk_3", "A", 3, 0.12),
+        _retrieved_chunk("B_chunk_2", "B", 2, 0.20),
+        _retrieved_chunk("C_chunk_1", "C", 1, 0.30),
+    )
+    chunks_by_document = {
+        "A": (
+            _retrieved_chunk("A_chunk_1", "A", 1, 0.11),
+            _retrieved_chunk("A_chunk_5", "A", 5, 0.10),
+            _retrieved_chunk("A_chunk_9", "A", 9, 0.13),
+        ),
+        "B": (
+            _retrieved_chunk("B_chunk_2", "B", 2, 0.20),
+            _retrieved_chunk("B_chunk_4", "B", 4, 0.21),
+        ),
+    }
+
+    def reranker(question, candidates):
+        return RerankResult(
+            results=(
+                RerankedCandidate("B_chunk_4", "B", "", 4, 0.99),
+                RerankedCandidate("A_chunk_1", "A", "", 0, 0.98),
+                RerankedCandidate("A_chunk_5", "A", "", 1, 0.97),
+                RerankedCandidate("B_chunk_2", "B", "", 3, 0.96),
+                RerankedCandidate("A_chunk_9", "A", "", 2, 0.95),
+            ),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    diagnostic = runner(
+        "Q001",
+        "diagnostic question",
+        ranked_chunks,
+        candidate_document_limit=2,
+        load_document_chunks=chunks_by_document.__getitem__,
+        candidate_pool_max_chunks=5,
+        reranker=reranker,
+        evidence_limit=3,
+        max_context_chunks=2,
+    )
+
+    assert diagnostic.question_id == "Q001"
+    assert diagnostic.question == "diagnostic question"
+    assert tuple(chunk.chunk_id for chunk in diagnostic.ranked_chunks) == (
+        "A_chunk_5",
+        "A_chunk_3",
+        "B_chunk_2",
+        "C_chunk_1",
+    )
+    assert diagnostic.candidate_document_ids == ("A", "B")
+    assert tuple(chunk.chunk_id for chunk in diagnostic.candidate_pool) == (
+        "A_chunk_1",
+        "A_chunk_5",
+        "A_chunk_9",
+        "B_chunk_2",
+        "B_chunk_4",
+    )
+    assert tuple(chunk.chunk_id for chunk in diagnostic.selected_evidence) == (
+        "B_chunk_4",
+        "A_chunk_1",
+        "A_chunk_5",
+    )
+    assert tuple(chunk.chunk_id for chunk in diagnostic.final_context) == (
+        "B_chunk_4",
+        "A_chunk_1",
+    )
+    assert diagnostic.final_context[0].document_id == "B"
+    assert diagnostic.final_context[0].chunk_index == 4
+    assert diagnostic.final_context[0].distance == pytest.approx(0.21)
+
+
+def test_document_local_diagnostic_records_stage_invocations():
+    runner = _document_local_diagnostic_runner()
+    loader_calls = []
+    reranker_calls = []
+    chunks_by_document = {
+        "A": (_retrieved_chunk("A_chunk_1", "A", 1, 0.10),),
+        "B": (_retrieved_chunk("B_chunk_1", "B", 1, 0.20),),
+    }
+
+    def load_document_chunks(document_id):
+        loader_calls.append(document_id)
+        return chunks_by_document[document_id]
+
+    def reranker(question, candidates):
+        reranker_calls.append(candidates)
+        return RerankResult(
+            results=tuple(
+                RerankedCandidate(
+                    candidate.chunk_id,
+                    candidate.document_id,
+                    candidate.content,
+                    index,
+                    1.0 - index,
+                )
+                for index, candidate in enumerate(candidates)
+            ),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    diagnostic = runner(
+        "Q002",
+        "stage count question",
+        (
+            _retrieved_chunk("A_ranked", "A", 1, 0.10),
+            _retrieved_chunk("B_ranked", "B", 1, 0.20),
+        ),
+        candidate_document_limit=2,
+        load_document_chunks=load_document_chunks,
+        candidate_pool_max_chunks=2,
+        reranker=reranker,
+        evidence_limit=2,
+        max_context_chunks=2,
+    )
+
+    assert loader_calls == ["A", "B"]
+    assert len(reranker_calls) == 1
+    assert tuple(candidate.chunk_id for candidate in reranker_calls[0]) == (
+        "A_chunk_1",
+        "B_chunk_1",
+    )
+    assert diagnostic.stage_invocations.dense_search == 0
+    assert diagnostic.stage_invocations.document_chunk_loader == len(loader_calls)
+    assert diagnostic.stage_invocations.evidence_reranker == 1
+    assert diagnostic.stage_invocations.generation == 0
+    assert diagnostic.stage_invocations.judge == 0
+
+
+def test_document_local_diagnostic_empty_ranked_input_has_zero_downstream_calls():
+    runner = _document_local_diagnostic_runner()
+
+    def forbidden_loader(*args):
+        raise AssertionError("empty ranked input must not load document chunks")
+
+    def forbidden_reranker(*args):
+        raise AssertionError("empty ranked input must not rerank evidence")
+
+    diagnostic = runner(
+        "Q003",
+        "empty question",
+        (),
+        candidate_document_limit=1,
+        load_document_chunks=forbidden_loader,
+        candidate_pool_max_chunks=1,
+        reranker=forbidden_reranker,
+        evidence_limit=1,
+        max_context_chunks=1,
+    )
+
+    assert diagnostic.candidate_document_ids == ()
+    assert diagnostic.candidate_pool == ()
+    assert diagnostic.selected_evidence == ()
+    assert diagnostic.final_context == ()
+    assert diagnostic.stage_invocations.dense_search == 0
+    assert diagnostic.stage_invocations.document_chunk_loader == 0
+    assert diagnostic.stage_invocations.evidence_reranker == 0
+    assert diagnostic.stage_invocations.generation == 0
+    assert diagnostic.stage_invocations.judge == 0
+
+
+@pytest.mark.parametrize(
+    "invalid_budget",
+    (
+        "candidate_document_limit",
+        "candidate_pool_max_chunks",
+        "evidence_limit",
+        "max_context_chunks",
+    ),
+)
+def test_document_local_diagnostic_validates_all_budgets_before_side_effects(
+    invalid_budget,
+):
+    runner = _document_local_diagnostic_runner()
+    calls = []
+    budgets = {
+        "candidate_document_limit": 1,
+        "candidate_pool_max_chunks": 1,
+        "evidence_limit": 1,
+        "max_context_chunks": 1,
+    }
+    budgets[invalid_budget] = 0
+
+    def forbidden_loader(*args):
+        calls.append("loader")
+        raise AssertionError("invalid budgets must fail before loading")
+
+    def forbidden_reranker(*args):
+        calls.append("reranker")
+        raise AssertionError("invalid budgets must fail before reranking")
+
+    with pytest.raises(ValueError):
+        runner(
+            "Q004",
+            "invalid budget question",
+            (_retrieved_chunk("A_chunk_1", "A", 1, 0.10),),
+            load_document_chunks=forbidden_loader,
+            reranker=forbidden_reranker,
+            **budgets,
+        )
+
+    assert calls == []
 
 
 def test_default_single_case_evaluator_uses_frozen_g0_retriever(monkeypatch):

--- a/tests/test_generation_eval_runner.py
+++ b/tests/test_generation_eval_runner.py
@@ -10,6 +10,11 @@ from experiments.evals.eval_techqa_generation import (
     run_resumable_generation_eval,
     write_generation_reports,
 )
+from experiments.evals.rerankers.qwen3_reranker import (
+    RerankCandidate,
+    RerankResult,
+    RerankedCandidate,
+)
 
 
 def _candidate_document_selector():
@@ -30,6 +35,16 @@ def _document_local_pool_builder():
     )
     assert builder is not None, "build_document_local_candidate_pool is not implemented"
     return builder
+
+
+def _document_local_evidence_selector():
+    selector = getattr(
+        generation_eval,
+        "select_document_local_evidence",
+        None,
+    )
+    assert selector is not None, "select_document_local_evidence is not implemented"
+    return selector
 
 
 def _retrieved_chunk(
@@ -329,6 +344,174 @@ def test_document_local_candidate_pool_requires_positive_budget(max_chunks):
             load_document_chunks=lambda _: (),
             max_chunks=max_chunks,
         )
+
+
+def test_evidence_selection_uses_relevance_order_over_pool_position():
+    selector = _document_local_evidence_selector()
+    pool = (
+        _retrieved_chunk("A_chunk_1", "A", 1, 0.40),
+        _retrieved_chunk("A_chunk_5", "A", 5, 0.20),
+        _retrieved_chunk("A_chunk_9", "A", 9, 0.30),
+        _retrieved_chunk("B_chunk_2", "B", 2, 0.25),
+    )
+    calls = []
+
+    def reranker(question, candidates):
+        calls.append((question, candidates))
+        return RerankResult(
+            results=(
+                RerankedCandidate("A_chunk_1", "A", "", 0, 0.99),
+                RerankedCandidate("B_chunk_2", "B", "", 3, 0.98),
+                RerankedCandidate("A_chunk_5", "A", "", 1, 0.97),
+                RerankedCandidate("A_chunk_9", "A", "", 2, 0.96),
+            ),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    selected = selector("Which evidence matters?   ", pool, reranker=reranker, limit=2)
+
+    assert tuple(chunk.chunk_id for chunk in selected) == ("A_chunk_1", "B_chunk_2")
+    assert len(calls) == 1
+    assert calls[0][0] == "Which evidence matters?"
+    assert calls[0][1] == (
+        RerankCandidate("A_chunk_1", "A", "content A_chunk_1"),
+        RerankCandidate("A_chunk_5", "A", "content A_chunk_5"),
+        RerankCandidate("A_chunk_9", "A", "content A_chunk_9"),
+        RerankCandidate("B_chunk_2", "B", "content B_chunk_2"),
+    )
+
+
+def test_evidence_selection_reranks_one_merged_document_pool():
+    selector = _document_local_evidence_selector()
+    pool = (
+        _retrieved_chunk("A_chunk_1", "A", 1, 0.10),
+        _retrieved_chunk("B_chunk_1", "B", 1, 0.20),
+    )
+    calls = []
+
+    def reranker(question, candidates):
+        calls.append((question, candidates))
+        return RerankResult(
+            results=tuple(
+                RerankedCandidate(
+                    candidate.chunk_id,
+                    candidate.document_id,
+                    candidate.content,
+                    index,
+                    1.0 - index,
+                )
+                for index, candidate in enumerate(candidates)
+            ),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    selector("question", pool, reranker=reranker, limit=2)
+
+    assert len(calls) == 1
+    assert tuple(candidate.chunk_id for candidate in calls[0][1]) == (
+        "A_chunk_1",
+        "B_chunk_1",
+    )
+
+
+def test_evidence_selection_returns_original_chunk_provenance():
+    selector = _document_local_evidence_selector()
+    source = generation_eval.G0RetrievedChunk(
+        chunk_id="A_chunk_1",
+        document_id="A",
+        chunk_index=1,
+        content="decisive evidence",
+        distance=0.417,
+    )
+
+    def reranker(question, candidates):
+        return RerankResult(
+            results=(
+                RerankedCandidate("A_chunk_1", "other", "rewritten", 99, 0.981),
+            ),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    selected = selector("question", (source,), reranker=reranker, limit=1)
+
+    assert selected == (source,)
+    assert selected[0].distance == pytest.approx(0.417)
+    assert selected[0].distance != pytest.approx(0.981)
+
+
+def test_evidence_selection_rejects_duplicate_candidate_chunk_id():
+    selector = _document_local_evidence_selector()
+    pool = (
+        _retrieved_chunk("shared_chunk", "A", 1, 0.10),
+        _retrieved_chunk("shared_chunk", "B", 2, 0.20),
+    )
+
+    def forbidden_reranker(*args):
+        raise AssertionError("duplicate candidate identity must fail before reranking")
+
+    with pytest.raises(RuntimeError, match="duplicate candidate"):
+        selector("question", pool, reranker=forbidden_reranker, limit=1)
+
+
+def test_evidence_selection_rejects_unknown_reranked_chunk_id():
+    selector = _document_local_evidence_selector()
+
+    def reranker(question, candidates):
+        return RerankResult(
+            results=(RerankedCandidate("unknown", "A", "", 0, 1.0),),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    with pytest.raises(RuntimeError, match="candidate pool"):
+        selector(
+            "question",
+            (_retrieved_chunk("A_chunk_1", "A", 1, 0.10),),
+            reranker=reranker,
+            limit=1,
+        )
+
+
+def test_evidence_selection_rejects_duplicate_reranked_chunk_id():
+    selector = _document_local_evidence_selector()
+
+    def reranker(question, candidates):
+        return RerankResult(
+            results=(
+                RerankedCandidate("A_chunk_1", "A", "", 0, 1.0),
+                RerankedCandidate("A_chunk_1", "A", "", 0, 0.9),
+            ),
+            request_id=None,
+            total_tokens=None,
+        )
+
+    with pytest.raises(RuntimeError, match="duplicate"):
+        selector(
+            "question",
+            (_retrieved_chunk("A_chunk_1", "A", 1, 0.10),),
+            reranker=reranker,
+            limit=2,
+        )
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_evidence_selection_requires_positive_limit(limit):
+    selector = _document_local_evidence_selector()
+
+    with pytest.raises(ValueError):
+        selector("question", (), reranker=lambda *_: None, limit=limit)
+
+
+def test_evidence_selection_empty_pool_avoids_reranker():
+    selector = _document_local_evidence_selector()
+
+    def forbidden_reranker(question, candidates):
+        raise AssertionError("empty pool must not call reranker")
+
+    assert selector("question", (), reranker=forbidden_reranker, limit=1) == ()
 
 
 def test_default_single_case_evaluator_uses_frozen_g0_retriever(monkeypatch):

--- a/tests/test_generation_eval_runner.py
+++ b/tests/test_generation_eval_runner.py
@@ -47,6 +47,16 @@ def _document_local_evidence_selector():
     return selector
 
 
+def _selected_evidence_context_assembler():
+    assembler = getattr(
+        generation_eval,
+        "assemble_selected_evidence_context",
+        None,
+    )
+    assert assembler is not None, "assemble_selected_evidence_context is not implemented"
+    return assembler
+
+
 def _retrieved_chunk(
     chunk_id: str,
     document_id: str,
@@ -512,6 +522,60 @@ def test_evidence_selection_empty_pool_avoids_reranker():
         raise AssertionError("empty pool must not call reranker")
 
     assert selector("question", (), reranker=forbidden_reranker, limit=1) == ()
+
+
+def test_selected_evidence_context_preserves_relevance_order():
+    assembler = _selected_evidence_context_assembler()
+    selected_evidence = (
+        _retrieved_chunk("A_chunk_5", "A", 5, 0.20),
+        _retrieved_chunk("A_chunk_1", "A", 1, 0.40),
+        _retrieved_chunk("B_chunk_2", "B", 2, 0.25),
+    )
+
+    context = assembler(selected_evidence, max_context_chunks=3)
+
+    assert tuple(chunk.chunk_id for chunk in context) == (
+        "A_chunk_5",
+        "A_chunk_1",
+        "B_chunk_2",
+    )
+
+
+def test_selected_evidence_context_deduplicates_chunk_ids():
+    assembler = _selected_evidence_context_assembler()
+    a1 = _retrieved_chunk("A_chunk_1", "A", 1, 0.10)
+
+    context = assembler(
+        (a1, a1, _retrieved_chunk("B_chunk_2", "B", 2, 0.20)),
+        max_context_chunks=3,
+    )
+
+    assert tuple(chunk.chunk_id for chunk in context) == ("A_chunk_1", "B_chunk_2")
+
+
+def test_selected_evidence_context_budget_counts_unique_chunks():
+    assembler = _selected_evidence_context_assembler()
+    a1 = _retrieved_chunk("A_chunk_1", "A", 1, 0.10)
+
+    context = assembler(
+        (
+            a1,
+            a1,
+            _retrieved_chunk("B_chunk_2", "B", 2, 0.20),
+            _retrieved_chunk("C_chunk_3", "C", 3, 0.30),
+        ),
+        max_context_chunks=2,
+    )
+
+    assert tuple(chunk.chunk_id for chunk in context) == ("A_chunk_1", "B_chunk_2")
+
+
+@pytest.mark.parametrize("max_context_chunks", [0, -1])
+def test_selected_evidence_context_requires_positive_budget(max_context_chunks):
+    assembler = _selected_evidence_context_assembler()
+
+    with pytest.raises(ValueError):
+        assembler((), max_context_chunks=max_context_chunks)
 
 
 def test_default_single_case_evaluator_uses_frozen_g0_retriever(monkeypatch):

--- a/tests/test_generation_eval_runner.py
+++ b/tests/test_generation_eval_runner.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+import experiments.evals.eval_techqa_generation as generation_eval
 from experiments.evals.adapters.techqa import TechQAGenerationCase
 from experiments.evals.eval_techqa_generation import (
     TechQAGenerationEvalResult,
@@ -9,6 +10,31 @@ from experiments.evals.eval_techqa_generation import (
     run_resumable_generation_eval,
     write_generation_reports,
 )
+
+
+def _candidate_document_selector():
+    selector = getattr(
+        generation_eval,
+        "select_candidate_document_ids",
+        None,
+    )
+    assert selector is not None, "select_candidate_document_ids is not implemented"
+    return selector
+
+
+def _retrieved_chunk(
+    chunk_id: str,
+    document_id: str,
+    chunk_index: int,
+    distance: float,
+) -> generation_eval.G0RetrievedChunk:
+    return generation_eval.G0RetrievedChunk(
+        chunk_id=chunk_id,
+        document_id=document_id,
+        chunk_index=chunk_index,
+        content=f"content {chunk_id}",
+        distance=distance,
+    )
 
 
 def _case(question_id: str, *, answerable: bool = True) -> TechQAGenerationCase:
@@ -158,6 +184,28 @@ def test_completed_checkpoint_rebuilds_summary_and_reports_without_evaluator(tmp
     assert metrics["correctness_mean"] == pytest.approx(0.8)
     assert metrics["faithfulness_mean"] == pytest.approx(0.9)
     assert len(result_lines) == 2
+
+
+def test_candidate_document_selection_deduplicates_repeated_document_slots():
+    selector = _candidate_document_selector()
+    ranked = (
+        _retrieved_chunk("A_chunk_3", "A", 3, 0.10),
+        _retrieved_chunk("A_chunk_5", "A", 5, 0.12),
+        _retrieved_chunk("B_chunk_2", "B", 2, 0.15),
+        _retrieved_chunk("A_chunk_1", "A", 1, 0.18),
+        _retrieved_chunk("C_chunk_4", "C", 4, 0.20),
+        _retrieved_chunk("D_chunk_2", "D", 2, 0.25),
+    )
+
+    assert selector(ranked, limit=3) == ("A", "B", "C")
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_candidate_document_selection_requires_positive_limit(limit):
+    selector = _candidate_document_selector()
+
+    with pytest.raises(ValueError):
+        selector((), limit=limit)
 
 
 def test_default_single_case_evaluator_uses_frozen_g0_retriever(monkeypatch):


### PR DESCRIPTION
## Summary

- add the G1 document-local evidence retrieval path and deterministic contract tests
- preserve the frozen G1 preregistration artifacts
- add the final G1 evidence-sufficiency decision report
- update the project and evaluation READMEs with the bounded G1 result

## G1 result

The 30-case method-label-blinded comparison improved aggregate evidence sufficiency over E1:

- COMPLETE: 24/30 -> 28/30
- INSUFFICIENT: 5/30 -> 1/30
- macro claim coverage: 0.825000 -> 0.955556
- pairwise movement: 6 wins / 22 ties / 2 losses

However, TRAIN_Q346 triggered the preregistered catastrophic-regression gate (E1=COMPLETE, G1=INSUFFICIENT), so the formal decision remains **NO_GO**. E1 remains the reference policy and G1 is retained as an evaluated experimental candidate.

A post-unblinding 65-claim forensic found 6 gained claims and 2 lost claims. The two regressions had different non-repeating failure boundaries (candidate-document admission and continuity), so no TRAIN-case-specific patch is admitted.

## Verification

Fresh verification on Python 3.11 with project + eval dependencies installed:

- `python -m pytest -q` -> **348 passed, 3 warnings**
- exit code 0
- worktree clean at `a73121161948e6b8bc0d0e70ba90b0657b565645`

Warnings are dependency deprecations / a ranx Numba cast warning and do not fail the suite.