### PR TITLE
Evaluate G2 rerank-informed document admission

### DIFF
--- a/docs/superpowers/plans/2026-09-08-g2-rerank-informed-document-admission.md
+++ b/docs/superpowers/plans/2026-09-08-g2-rerank-informed-document-admission.md
@@ -1,0 +1,708 @@
+# G2 Rerank-Informed Document Admission Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and evaluate G2-A, where the first five candidate documents are admitted by the already-computed global rerank order rather than Dense order, while all G1 downstream document-local evidence mechanics remain fixed.
+
+**Architecture:** Add a focused offline G2 evaluation module that consumes the historical E0 Dense Top100 and an injected/replayed global `RerankResult`. G1 and G2-A share the same Dense input and downstream document-local expansion / merged rerank / Top16 contracts; only the ranking used for document admission differs. Formal evaluation uses a fresh preregistered TRAIN sample and a two-method blinded evidence-sufficiency review.
+
+**Tech Stack:** Python 3.11, pytest, dataclasses, existing TechQA frozen artifacts, existing `qwen3-rerank` provider adapter.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-g2-rerank-informed-document-admission-design.md`
+
+## Global Constraints
+
+- Baseline commit: `7caf1a1245bdc73698c9fb218c863425ae3b7f8f`.
+- Work only on `feat/g2-rerank-informed-admission`.
+- Historical E0 Dense Top100 remains the input candidate pool.
+- Global reranker remains `qwen3-rerank` with instruction exactly `Rank the candidate passages by relevance to resolving the technical support query.`.
+- Candidate document limit remains exactly `5`.
+- Candidate pool safety ceiling remains `500` chunks.
+- Evidence limit remains `16`; final context limit remains `16`.
+- G2-A performs no continuity/sibling-preservation change.
+- G2-A performs no query rewrite, BM25/Hybrid addition, alternate reranker, per-document rerank, second-pass rerank, embedding, generation, or judge call.
+- The global Top100 rerank result is injected/reused; G2 orchestration must not issue a second equivalent global rerank call.
+- No Q346/Q492-specific logic.
+- Previous G1 30 cases and prior manually labeled evidence cases are excluded from fresh formal sampling.
+- Paid execution cannot begin until sample, contracts, and GO/NO-GO gates are frozen in-repo.
+
+---
+
+## File map
+
+**Create**
+
+- `experiments/evals/eval_techqa_g2_admission.py` — G2-A admission/result validation and pure G1-vs-G2 comparison orchestration.
+- `tests/test_eval_techqa_g2_admission.py` — deterministic unit/contract tests for the new orchestration.
+- `experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json` — frozen fresh-sample/provider/metric/gate contract, created only after deterministic offline generation.
+- `experiments/evals/reports/g2_rerank_informed_admission/README.md` — experiment scope, artifact lineage, and result boundary.
+
+**Modify only if required by typing reuse**
+
+- `experiments/evals/eval_techqa_generation.py` — behavior-preserving type generalization for `select_candidate_document_ids()`; no G1 semantic change.
+
+**Reuse without changing behavior**
+
+- `experiments/evals/rerankers/qwen3_reranker.py` — `RerankResult`, `RerankedCandidate`, `rerank_candidates`.
+- `experiments/evals/eval_techqa_generation.py` — `G0RetrievedChunk`, `select_candidate_document_ids`, `build_document_local_candidate_pool`, `select_document_local_evidence`, `assemble_selected_evidence_context`.
+- `experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json` — prior 30-case exclusion set.
+- `experiments/evals/reports/r1_evidence_audit/evidence_labels.jsonl` — prior manual-label exclusion set.
+
+---
+
+### Task 1: Pure rerank-informed document admission
+
+**Files:**
+- Create: `experiments/evals/eval_techqa_g2_admission.py`
+- Test: `tests/test_eval_techqa_g2_admission.py`
+- Modify if necessary: `experiments/evals/eval_techqa_generation.py`
+
+**Interfaces:**
+- Consumes: `RerankResult.results: tuple[RerankedCandidate, ...]`.
+- Produces: `select_rerank_informed_document_ids(shared_rerank: RerankResult, *, limit: int) -> tuple[str, ...]`.
+
+- [ ] **Step 1: Write RED tests for rerank-order admission**
+
+```python
+from experiments.evals.eval_techqa_g2_admission import (
+    select_rerank_informed_document_ids,
+)
+from experiments.evals.rerankers.qwen3_reranker import (
+    RerankResult,
+    RerankedCandidate,
+)
+
+
+def _shared_rerank(*doc_ids: str) -> RerankResult:
+    return RerankResult(
+        results=tuple(
+            RerankedCandidate(
+                chunk_id=f"c{index}",
+                document_id=document_id,
+                content=f"content-{index}",
+                original_index=index,
+                relevance_score=1.0 - index / 100.0,
+            )
+            for index, document_id in enumerate(doc_ids)
+        ),
+        request_id="shared",
+        total_tokens=123,
+    )
+
+
+def test_rerank_informed_admission_uses_first_unique_docs_in_rerank_order():
+    result = _shared_rerank("D3", "D3", "D1", "D5", "D2", "D4", "D6")
+    assert select_rerank_informed_document_ids(result, limit=5) == (
+        "D3", "D1", "D5", "D2", "D4"
+    )
+
+
+def test_rerank_informed_admission_requires_positive_limit():
+    with pytest.raises(ValueError):
+        select_rerank_informed_document_ids(_shared_rerank("D1"), limit=0)
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py -q
+```
+
+Expected: collection/import failure because the new G2 module/function does not exist.
+
+- [ ] **Step 3: Implement the minimal selector**
+
+```python
+from experiments.evals.rerankers.qwen3_reranker import RerankResult
+
+
+def select_rerank_informed_document_ids(
+    shared_rerank: RerankResult,
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    seen: set[str] = set()
+    selected: list[str] = []
+    for candidate in shared_rerank.results:
+        document_id = str(candidate.document_id)
+        if document_id in seen:
+            continue
+        seen.add(document_id)
+        selected.append(document_id)
+        if len(selected) >= limit:
+            break
+    return tuple(selected)
+```
+
+- [ ] **Step 4: Run focused tests and existing G1 selector tests**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py tests/test_generation_eval_runner.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+git commit -m "feat: add rerank-informed document admission"
+```
+
+---
+
+### Task 2: G2-A diagnostic path reusing the shared global rerank
+
+**Files:**
+- Modify: `experiments/evals/eval_techqa_g2_admission.py`
+- Test: `tests/test_eval_techqa_g2_admission.py`
+
+**Interfaces:**
+- Consumes: historical E0 `Sequence[G0RetrievedChunk]`, injected `RerankResult`, offline document loader, merged reranker.
+- Produces:
+
+```python
+@dataclass(frozen=True)
+class G2AdmissionDiagnostic:
+    question_id: str
+    question: str
+    dense_ranked_chunks: tuple[G0RetrievedChunk, ...]
+    candidate_document_ids: tuple[str, ...]
+    candidate_pool: tuple[G0RetrievedChunk, ...]
+    selected_evidence: tuple[G0RetrievedChunk, ...]
+    final_context: tuple[G0RetrievedChunk, ...]
+    merged_rerank_invocations: int
+
+
+def run_g2_admission_diagnostic(
+    question_id: str,
+    question: str,
+    dense_ranked_chunks: Sequence[G0RetrievedChunk],
+    *,
+    shared_global_rerank: RerankResult,
+    candidate_document_limit: int,
+    load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
+    candidate_pool_max_chunks: int,
+    merged_reranker: Callable[..., Any],
+    evidence_limit: int,
+    max_context_chunks: int,
+) -> G2AdmissionDiagnostic:
+    ...
+```
+
+- [ ] **Step 1: Add RED contract tests**
+
+Tests must prove all of the following with synthetic chunks:
+
+```text
+Dense first5 docs != global-rerank first5 docs
+G2 candidate docs follow global-rerank order
+G2 loads only those five documents
+G2 calls only the merged reranker once
+G2 never calls a global reranker because the global result is injected
+G2 reuses build_document_local_candidate_pool()
+G2 reuses select_document_local_evidence()
+G2 reuses assemble_selected_evidence_context()
+final context preserves merged-rerank order and max16 semantics
+invalid budgets fail before loader/reranker side effects
+```
+
+Use a fake merged reranker returning a complete deterministic permutation. Include a regression test where Dense order begins `D1,D2,D3,D4,D5,...` but shared rerank begins chunks from `D9,D8,D7,D6,D5,...`; assert G2 admits `D9,D8,D7,D6,D5`.
+
+- [ ] **Step 2: Run focused test file and verify RED**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py -q
+```
+
+Expected: FAIL on missing diagnostic dataclass/function.
+
+- [ ] **Step 3: Implement the minimal diagnostic runner**
+
+Implementation sequence must be exactly:
+
+```python
+candidate_document_ids = select_rerank_informed_document_ids(
+    shared_global_rerank,
+    limit=candidate_document_limit,
+)
+candidate_pool = build_document_local_candidate_pool(
+    candidate_document_ids,
+    load_document_chunks=load_document_chunks,
+    max_chunks=candidate_pool_max_chunks,
+)
+selected_evidence = select_document_local_evidence(
+    question,
+    candidate_pool,
+    reranker=tracked_merged_reranker,
+    limit=evidence_limit,
+)
+final_context = assemble_selected_evidence_context(
+    selected_evidence,
+    max_context_chunks=max_context_chunks,
+)
+```
+
+Do not call `rerank_candidates()` for the global stage inside this function.
+
+- [ ] **Step 4: Run G2 + G1 focused tests**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py tests/test_generation_eval_runner.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+git commit -m "feat: add G2 admission diagnostic path"
+```
+
+---
+
+### Task 3: One-variable G1-vs-G2 comparison contract
+
+**Files:**
+- Modify: `experiments/evals/eval_techqa_g2_admission.py`
+- Test: `tests/test_eval_techqa_g2_admission.py`
+
+**Interfaces:**
+- Produces a pure comparison record containing G1/G2 admitted docs and contexts from the same Dense Top100.
+
+```python
+@dataclass(frozen=True)
+class G1G2AdmissionComparison:
+    question_id: str
+    dense_candidate_chunk_ids: tuple[str, ...]
+    g1_candidate_document_ids: tuple[str, ...]
+    g2_candidate_document_ids: tuple[str, ...]
+    g1_context: tuple[G0RetrievedChunk, ...]
+    g2_context: tuple[G0RetrievedChunk, ...]
+```
+
+- [ ] **Step 1: Add RED tests proving causal isolation**
+
+Construct one Dense ranking and one shared global rerank. Assert:
+
+```python
+assert g1_candidate_document_ids == select_candidate_document_ids(
+    dense_ranked_chunks, limit=5
+)
+assert g2_candidate_document_ids == select_rerank_informed_document_ids(
+    shared_global_rerank, limit=5
+)
+```
+
+Also assert both branches receive identical values for:
+
+```text
+candidate_pool_max_chunks=500
+evidence_limit=16
+max_context_chunks=16
+same offline loader
+same merged-reranker contract shape
+```
+
+Do not require identical merged-rerank outputs because candidate pools may differ.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py -q
+```
+
+- [ ] **Step 3: Implement the comparison function**
+
+The G1 branch must use existing `select_candidate_document_ids(dense_ranked_chunks, limit=5)` and existing downstream helpers. The G2 branch must use the injected global rerank result and the same downstream helpers. Keep the comparison offline and dependency-injected.
+
+- [ ] **Step 4: Run focused tests and static checks**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py tests/test_generation_eval_runner.py -q
+conda run -n enterprise-g1-verify ruff check experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+git commit -m "test: freeze G1 versus G2 causal contract"
+```
+
+---
+
+### Task 4: Deterministic fresh-sample preregistration builder
+
+**Files:**
+- Modify: `experiments/evals/eval_techqa_g2_admission.py`
+- Test: `tests/test_eval_techqa_g2_admission.py`
+- Create after offline generation: `experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json`
+
+**Interfaces:**
+
+```python
+G2_SAMPLE_SEED = "techqa-g2-rerank-informed-admission-v1"
+G2_SAMPLE_SIZE = 30
+
+
+def select_g2_preregistered_cases(
+    cases: Sequence[TechQAGenerationCase],
+    *,
+    e0_trace_by_question_id: Mapping[str, Sequence[G0RetrievedChunk]],
+    relevant_document_by_question_id: Mapping[str, str],
+    excluded_question_ids: Collection[str],
+    seed: str = G2_SAMPLE_SEED,
+    sample_size: int = G2_SAMPLE_SIZE,
+) -> tuple[str, ...]:
+    ...
+```
+
+- [ ] **Step 1: Add RED tests for eligibility and deterministic selection**
+
+Tests must show:
+
+- impossible cases excluded;
+- non-TRAIN cases excluded;
+- missing E0 trace excluded;
+- formal relevant document absent from Dense Top100 excluded;
+- formal relevant doc may be outside Dense first5 and the case remains eligible;
+- prior exclusion IDs are removed before hashing;
+- sorting is exactly SHA256 of `seed + ':' + question_id`, then `question_id` as tiebreaker;
+- same inputs produce exactly the same 30 IDs;
+- insufficient eligible population raises `ValueError` rather than silently shrinking/resampling.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py -q
+```
+
+- [ ] **Step 3: Implement deterministic eligibility/selection**
+
+No random module or shuffle. Use `hashlib.sha256` only.
+
+- [ ] **Step 4: Build the exclusion set offline**
+
+Programmatically union:
+
+```text
+historical G0 12-case pilot IDs
+G1 preregistration selected_case_ids (30)
+question_id values from reports/r1_evidence_audit/evidence_labels.jsonl
+explicit G1 forensic IDs not already covered
+```
+
+Persist the exact exclusion count and SHA256 of the sorted exclusion list in the preregistration artifact.
+
+- [ ] **Step 5: Generate the preregistration JSON with no provider calls**
+
+The artifact must freeze at minimum:
+
+```json
+{
+  "experiment_id": "techqa_g2_rerank_informed_admission_v1",
+  "artifact_state": "PREREGISTRATION_BEFORE_PAID_EXECUTION",
+  "baseline_commit": "7caf1a1245bdc73698c9fb218c863425ae3b7f8f",
+  "sample_seed": "techqa-g2-rerank-informed-admission-v1",
+  "sample_size": 30,
+  "selected_case_ids": [],
+  "eligibility_rule": {},
+  "exclusion_contract": {},
+  "g1_contract": {},
+  "g2_contract": {},
+  "rerank_contract": {},
+  "provider_call_budget": {
+    "shared_global_calls_per_case": 1,
+    "g1_merged_calls_per_case": 1,
+    "g2_merged_calls_per_case": 1,
+    "max_real_rerank_calls": 90,
+    "max_embedding_calls": 0,
+    "max_generation_calls": 0,
+    "max_judge_calls": 0
+  },
+  "go_no_go_rule": {}
+}
+```
+
+`go_no_go_rule` must exactly freeze the spec gates before any provider call.
+
+- [ ] **Step 6: Run tests, JSON parse check, and commit**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py -q
+conda run -n enterprise-g1-verify python -m json.tool experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json > $null
+```
+
+```bash
+git add experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json
+git commit -m "eval: preregister fresh G2 admission comparison"
+```
+
+---
+
+### Task 5: Offline preflight and call-graph tripwires
+
+**Files:**
+- Modify: `experiments/evals/eval_techqa_g2_admission.py`
+- Test: `tests/test_eval_techqa_g2_admission.py`
+- Create: `experiments/evals/reports/g2_rerank_informed_admission/README.md`
+
+**Interfaces:**
+- Preflight accepts only frozen E0 traces, frozen corpus chunk loader, and replay/fake rerank results.
+- It must be runnable with no network/API credentials.
+
+- [ ] **Step 1: Add RED tripwire tests**
+
+Tests must fail if preflight attempts any of:
+
+```text
+live Dense/Chroma query
+provider global rerank
+generation
+judge
+embedding
+```
+
+Also verify per case:
+
+```text
+Dense Top100 count/identity preserved
+G1 admission = Dense first5 unique docs
+G2 admission = replayed shared-rerank first5 unique docs
+candidate pool <= 500
+final context <= 16
+no duplicate chunk IDs
+all loaded chunks belong to admitted documents
+```
+
+- [ ] **Step 2: Implement minimal offline preflight summary**
+
+Persist descriptive capacity stats only; do not tune thresholds from them.
+
+- [ ] **Step 3: Run preflight twice and compare deterministic fingerprints**
+
+Fingerprint canonical per-case fields:
+
+```text
+question_id
+Dense chunk IDs
+G1 admitted doc IDs
+G2 admitted doc IDs
+G1 candidate chunk IDs
+G2 candidate chunk IDs
+```
+
+Two offline runs must produce identical SHA256.
+
+- [ ] **Step 4: Update experiment README**
+
+Document:
+
+- G1 is still the reference/evaluated predecessor;
+- G2-A is not serving code;
+- previous 30 G1 cases are excluded from confirmation;
+- G2-A changes only admission ranking;
+- continuity remains explicitly out of scope;
+- paid execution is authorized only after preflight passes.
+
+- [ ] **Step 5: Run full local verification before paid execution**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py tests/test_generation_eval_runner.py -q
+conda run -n enterprise-g1-verify ruff check experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+conda run -n enterprise-g1-verify python -m compileall -q experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py experiments/evals/reports/g2_rerank_informed_admission/README.md
+git commit -m "eval: add G2 offline preflight gates"
+```
+
+---
+
+### Task 6: Paid rerank execution
+
+**Files:**
+- No code changes unless execution exposes a contract bug that reproduces offline first.
+- Raw paid artifacts stay outside Git; compact frozen summary hashes may be recorded later.
+
+**Interfaces:**
+- Per case real call graph is exactly `1 shared global + 1 G1 merged + 1 G2 merged = 3` rerank calls.
+
+- [ ] **Step 1: Verify exact preregistration and preflight fingerprints before provider access**
+
+Abort if worktree is dirty, HEAD differs from the preregistered execution commit, sample differs, or any budget differs.
+
+- [ ] **Step 2: Execute only the 30 frozen cases**
+
+Provider failure policy:
+
+```text
+STOP immediately
+preserve partial artifacts
+no retry
+no model change
+no candidate truncation
+no case replacement
+```
+
+- [ ] **Step 3: Validate execution ledger**
+
+Required totals on success:
+
+```text
+cases = 30
+shared_global_calls = 30
+g1_merged_calls = 30
+g2_merged_calls = 30
+total_real_rerank_calls = 90
+embedding_calls = 0
+generation_calls = 0
+judge_calls = 0
+```
+
+Record token usage separately for each of the three call classes.
+
+- [ ] **Step 4: Produce method contexts and sealed A/B mapping**
+
+Do not expose method labels to the evidence reviewer.
+
+---
+
+### Task 7: Two-method blinded evidence-sufficiency review
+
+**Files:**
+- Raw reviewer artifacts stay outside Git until final compact result is frozen.
+
+**Interfaces:**
+- 30 questions × 2 anonymous contexts = 60 review units.
+- Claim decomposition is frozen before contexts are opened.
+
+- [ ] **Step 1: Freeze material claims from question + gold answer only**
+
+Reuse G1 support semantics exactly. Do not inspect A/B contexts while decomposing claims.
+
+- [ ] **Step 2: Build sanitized A/B review packets**
+
+Allowed fields:
+
+```text
+opaque unit_id
+question
+frozen claim IDs/text/required identifiers
+anonymous context passages P1..Pn
+```
+
+Forbidden fields:
+
+```text
+G1/G2 names
+raw document/chunk IDs
+rerank scores/ranks
+method provenance
+provider request IDs
+```
+
+- [ ] **Step 3: Review every claim-context pair**
+
+Labels:
+
+```text
+EXPLICIT_SUPPORT
+COMPOSABLE_SUPPORT
+INFERENCE_ONLY
+ABSENT
+UNRESOLVED
+```
+
+- [ ] **Step 4: Deterministically aggregate anonymous contexts**
+
+Compute `COMPLETE/PARTIAL/INSUFFICIENT/UNRESOLVED` and per-case claim coverage before unblinding.
+
+---
+
+### Task 8: Unblind, decision, and closeout
+
+**Files:**
+- Create: `experiments/evals/reports/g2_rerank_informed_admission/final_decision.md`
+- Modify: `experiments/evals/reports/g2_rerank_informed_admission/README.md`
+- Modify root/eval README only if the result materially changes the documented evaluation lineage.
+
+**Interfaces:**
+- Input is the frozen anonymous aggregation plus sealed mapping.
+
+- [ ] **Step 1: Unblind exactly once after review freeze**
+
+Calculate:
+
+```text
+G1/G2 COMPLETE counts
+G1/G2 PARTIAL counts
+G1/G2 INSUFFICIENT counts
+macro mean per-case claim coverage
+G2 wins / ties / losses
+catastrophic regressions: G1 COMPLETE -> G2 INSUFFICIENT
+provider token/call descriptors
+```
+
+- [ ] **Step 2: Apply preregistered gates without relaxation**
+
+GO requires all of:
+
+```text
+30/30 executed under frozen contract
+UNRESOLVED = 0
+G2 COMPLETE >= G1 COMPLETE
+G2 INSUFFICIENT <= G1 INSUFFICIENT
+G2 macro claim coverage >= G1 macro claim coverage
+G2 wins > G2 losses
+catastrophic regressions = 0
+```
+
+- [ ] **Step 3: Write bounded final decision**
+
+If GO, wording is limited to authorization for the next design/evaluation stage. If NO_GO, preserve the result and diagnose before any new architecture change. Never call this production generation uplift or frozen DEV improvement.
+
+- [ ] **Step 4: Run fresh full-suite verification**
+
+```powershell
+conda run -n enterprise-g1-verify python -m pytest -q
+conda run -n enterprise-g1-verify ruff check experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+```
+
+Expected baseline remains no test failures; any new failure blocks merge.
+
+- [ ] **Step 5: Commit closeout, open PR, review, and merge only after CI success**
+
+```bash
+git add experiments/evals/reports/g2_rerank_informed_admission README.md experiments/evals/README.md
+git commit -m "docs: close G2 admission experiment"
+```
+
+PR title:
+
+```text
+Evaluate G2 rerank-informed document admission
+```
+
+Do not merge until fresh local verification and GitHub Actions both succeed.
+
+---
+
+## Self-review
+
+- Spec coverage: every frozen invariant, sampling rule, call budget, leakage rule, metric, and GO/NO-GO gate maps to Tasks 1-8.
+- Placeholder scan: no implementation step depends on `TBD`, `TODO`, or outcome-dependent tuning.
+- Type consistency: G2 consumes existing `RerankResult`, `G0RetrievedChunk`, and G1 downstream helper contracts; new names are fixed in Tasks 1-3.
+- One-variable check: G1 uses Dense order for document admission; G2-A uses shared global-rerank order. Candidate document count, document expansion, merged rerank, Top16, context cap, model, and instruction stay fixed.
+- Anti-overfitting check: Q346/Q492 are diagnostic only; previous G1 30 and prior manual evidence-label cases are excluded from fresh formal sampling.
+- Cost check: formal 30-case comparison has a hard maximum of 90 real rerank calls and zero embedding/generation/judge calls.

--- a/docs/superpowers/specs/2026-09-08-g2-rerank-informed-document-admission-design.md
+++ b/docs/superpowers/specs/2026-09-08-g2-rerank-informed-document-admission-design.md
@@ -1,0 +1,290 @@
+# G2 Rerank-Informed Document Admission Design
+
+## Status
+
+Approved experimental design for the next TechQA evidence-retrieval iteration after G1.
+
+This is a **bounded retrieval/evidence experiment**, not a serving-path migration. The only architecture variable under test is **which ranking determines admission of the first five candidate documents**.
+
+Baseline commit: `7caf1a1245bdc73698c9fb218c863425ae3b7f8f`.
+
+## Problem
+
+G1 improved aggregate evidence sufficiency over E1, but the preregistered replacement gate remained `NO_GO` because one catastrophic regression occurred. The G1 closeout identified `TRAIN_Q346` as a candidate-document admission miss: a decisive chunk was present deep in the historical Dense Top100 and could be promoted by the strong global reranker, but G1 permanently excluded its document before that reranker could influence document admission.
+
+The engineering lesson is broader than that case:
+
+> A weak first-stage ranking should not receive an irreversible document-admission veto before a stronger reranker has had a chance to reorder the already-retrieved candidate pool.
+
+This design must not encode Q346- or Q492-specific logic. Those cases are diagnostic/development evidence only and are excluded from fresh confirmation.
+
+## Existing contracts
+
+### E1 reference
+
+```text
+historical E0 Dense Top100
+        ↓
+one shared qwen3-rerank over Top100
+        ↓
+Top3 rerank anchors + historical Dense rank1 rescue
+        ↓
+anchor + up to 3 forward siblings per unique anchor document
+        ↓
+dedupe
+        ↓
+max16 context
+```
+
+The existing implementation is `retrieve_g0_e1_context()` in `experiments/evals/eval_techqa_generation.py`.
+
+### G1 candidate
+
+```text
+historical E0 Dense Top100 order
+        ↓
+first 5 unique documents by Dense order
+        ↓
+full frozen document-local chunk expansion
+        ↓
+one merged qwen3-rerank
+        ↓
+Top16 selected evidence
+        ↓
+max16 context
+```
+
+The existing reusable G1 helpers in `experiments/evals/eval_techqa_generation.py` are:
+
+- `select_candidate_document_ids()`
+- `build_document_local_candidate_pool()`
+- `select_document_local_evidence()`
+- `assemble_selected_evidence_context()`
+- `run_document_local_evidence_diagnostic()`
+
+The reranker implementation is `rerank_candidates()` in `experiments/evals/rerankers/qwen3_reranker.py`.
+
+## G2-A hypothesis
+
+G2-A keeps all G1 downstream evidence-construction behavior fixed and changes only candidate-document admission order:
+
+```text
+historical E0 Dense Top100
+        ↓
+shared global qwen3-rerank over the same Top100
+        ↓
+first 5 unique documents by GLOBAL RERANK order
+        ↓
+full frozen document-local chunk expansion
+        ↓
+one merged qwen3-rerank
+        ↓
+Top16 selected evidence
+        ↓
+max16 context
+```
+
+The shared global rerank is an injected/replayed result. The G2 diagnostic path must **not** perform a second equivalent global provider call.
+
+### Exact causal variable
+
+G1:
+
+```text
+candidate_doc_ids = first 5 unique document IDs in Dense Top100 order
+```
+
+G2-A:
+
+```text
+candidate_doc_ids = first 5 unique document IDs in shared global-rerank order
+```
+
+Everything after `candidate_doc_ids` remains the same G1 mechanism.
+
+## Frozen invariants
+
+The following are fixed for G2-A and must not be tuned after looking at results:
+
+- input candidate pool remains the historical/frozen E0 Dense Top100 chunks;
+- global reranker remains `qwen3-rerank`;
+- global rerank instruction remains exactly `Rank the candidate passages by relevance to resolving the technical support query.`;
+- global rerank must be computed once per case and reused by any method that needs it;
+- candidate document limit remains exactly `5`;
+- candidate document order is first occurrence in the chosen ranking;
+- admitted documents are expanded using the frozen/offline TechQA corpus;
+- candidate pool safety ceiling remains `500` chunks;
+- merged evidence reranker remains the same `qwen3-rerank` contract;
+- final evidence limit remains `16`;
+- final context limit remains `16`;
+- no query rewrite;
+- no BM25/Hybrid addition;
+- no alternate reranker;
+- no per-document rerank;
+- no second-pass rerank;
+- no gold labels or gold answers may influence retrieval;
+- no case-specific rescue logic;
+- no continuity/sibling-preservation change in G2-A.
+
+Q492's continuity miss is intentionally **not** fixed in this experiment. Continuity remains a separate future causal variable.
+
+## Code organization
+
+G2-specific orchestration should live in a focused module instead of further expanding the already-large generation harness:
+
+- create `experiments/evals/eval_techqa_g2_admission.py` for G2-A admission and comparison orchestration;
+- create `tests/test_eval_techqa_g2_admission.py` for pure contract tests;
+- reuse G1 pool construction, merged evidence selection, and context assembly from `eval_techqa_generation.py`;
+- reuse `RerankResult` / `RerankedCandidate` / `rerank_candidates` from `experiments/evals/rerankers/qwen3_reranker.py`;
+- do not modify the online API/serving retrieval path.
+
+If the existing `select_candidate_document_ids()` type annotation prevents safe reuse with `RerankedCandidate`, only a behavior-preserving typing generalization is allowed. G1 ordering semantics must stay unchanged and remain covered by its existing tests.
+
+## Fresh evaluation population
+
+The previous G1 30-case set is now development/diagnostic evidence for this architecture and cannot confirm G2-A.
+
+The new preregistered development sample is drawn from answerable `TRAIN_*` cases with:
+
+1. a frozen historical E0 Top100 trace;
+2. exactly one formal relevant TechQA document;
+3. at least one chunk from that formal relevant document somewhere in the historical E0 Top100.
+
+The eligibility boundary intentionally changes from G1's `formal relevant doc in Dense first5` condition to `formal relevant doc in Dense Top100` because document admission itself is the variable under test. Conditioning on Dense first5 would partially pre-select for the G1 admission policy.
+
+Exclude before sampling:
+
+- the historical 12-case G0 generation pilot;
+- all 30 cases from `evidence_sufficiency_30case_preregistration_v1_1.json`;
+- all TRAIN question IDs that appear in repository-frozen manual evidence-label artifacts, including `reports/r1_evidence_audit/evidence_labels.jsonl`;
+- any additional explicitly enumerated case IDs that were manually inspected during prior G1 forensic work, if not already covered by the sets above.
+
+Selection is deterministic:
+
+```text
+seed = techqa-g2-rerank-informed-admission-v1
+key(qid) = sha256(seed + ':' + qid).hexdigest()
+sort ascending by (key, qid)
+select first 30 eligible cases
+```
+
+No replacement, resampling, outcome-based exclusion, or parameter change is allowed after the sample is frozen.
+
+This remains a **fresh preregistered TRAIN development confirmation**, not the project's frozen DEV held-out benchmark. A DEV confirmation, if later justified, is a separate experiment and is not part of G2-A implementation.
+
+## Method comparison
+
+Primary comparison: **G1 vs G2-A**.
+
+For each fresh case:
+
+```text
+historical E0 Dense Top100
+        │
+        ├── G1 admission: first5 docs by Dense order
+        │       ↓
+        │   full-doc expansion
+        │       ↓
+        │   merged rerank
+        │       ↓
+        │   Top16
+        │
+        └── one shared global rerank over Top100
+                ↓
+            G2-A admission: first5 docs by rerank order
+                ↓
+            full-doc expansion
+                ↓
+            merged rerank
+                ↓
+            Top16
+```
+
+The two methods therefore share the same Dense input and all downstream G1 mechanisms; only the ranking used for document admission differs.
+
+Expected real rerank call graph per case during formal comparison:
+
+- shared global Top100 rerank: `1`;
+- G1 merged document-local rerank: `1`;
+- G2-A merged document-local rerank: `1`;
+- total: `3` real rerank calls per case;
+- embedding: `0`;
+- generation: `0`;
+- judge/provider LLM: `0`.
+
+For 30 cases, the hard maximum is therefore `90` real rerank calls. Provider failures stop the run; no retry, candidate truncation, case replacement, or model change is allowed.
+
+## Evidence-sufficiency rubric
+
+Reuse the frozen G1 claim-support semantics rather than inventing a new quality metric:
+
+Claim support labels:
+
+- `EXPLICIT_SUPPORT`
+- `COMPOSABLE_SUPPORT`
+- `INFERENCE_ONLY`
+- `ABSENT`
+- `UNRESOLVED`
+
+Covered labels are only `EXPLICIT_SUPPORT` and `COMPOSABLE_SUPPORT`.
+
+Per-context status:
+
+- `COMPLETE`: all frozen material claims covered;
+- `PARTIAL`: at least one but not all claims covered;
+- `INSUFFICIENT`: zero material claims covered;
+- `UNRESOLVED`: support cannot be judged reliably.
+
+Primary aggregate metric is macro mean per-case claim coverage.
+
+Claims must be frozen from question + gold answer **before** opening either method context. Context review is method-label blinded. Because the primary comparison now has two methods, use anonymous labels `A/B` rather than rebuilding the previous three-method `A/B/C` packet.
+
+## Preregistered decision rule
+
+Before any paid G2-A execution, freeze the exact GO/NO-GO gate.
+
+`GO_TO_NEXT_STAGE=yes` only if all are true:
+
+- all 30 cases execute under the frozen provider/capacity contract;
+- unresolved evidence-review count is `0`;
+- `G2_complete_count >= G1_complete_count`;
+- `G2_insufficient_count <= G1_insufficient_count`;
+- `G2_macro_claim_coverage >= G1_macro_claim_coverage`;
+- pairwise ordinal `G2_wins > G2_losses`;
+- catastrophic regression count is `0`, where catastrophic regression is `G1=COMPLETE && G2=INSUFFICIENT`.
+
+If all contexts tie, G2-A does not justify its additional global-rerank cost and therefore does not pass the strict `wins > losses` gate.
+
+A GO only authorizes a next design/evaluation stage. It does not establish production accuracy, latency improvement, statistical significance, or serving-path promotion.
+
+## Cost and latency boundary
+
+G2-A adds a global rerank stage relative to standalone G1. Track provider call count and returned token usage separately for:
+
+- shared global rerank;
+- G1 merged rerank;
+- G2-A merged rerank.
+
+These are descriptive engineering costs, not quality-gate inputs. Offline wall-clock timing must not be presented as production latency improvement/regression without a dedicated controlled runtime experiment.
+
+## Leakage and anti-overfitting rules
+
+Do not:
+
+- tune `5`, `16`, or `500` from the new sample;
+- add Q346-specific document rescue;
+- add Q492-specific sibling preservation;
+- inspect method labels while freezing claims;
+- inspect G2 outcomes before the sample and gates are frozen;
+- replace cases after provider or capacity failure;
+- call the same global rerank twice to simplify code;
+- report this TRAIN experiment as frozen DEV evidence;
+- promote G2-A to the serving path from this experiment alone.
+
+## Success interpretation
+
+The experiment is designed to answer one causal question:
+
+> Does moving document admission from Dense order to an already-available stronger global-rerank order preserve or improve G1 evidence sufficiency on fresh cases without introducing new catastrophic regressions?
+
+A result outside that question should not be inferred from G2-A.

--- a/experiments/evals/README.md
+++ b/experiments/evals/README.md
@@ -287,6 +287,23 @@ Important boundary:
 
 > The G1 result is a conditional evidence-sufficiency experiment on TRAIN cases under a frozen Stage2 contract. It is **not** a production generation uplift, a full-TechQA retrieval improvement, or evidence that G1 replaced E1.
 
+### G2-A rerank-informed document admission
+
+G2-A tested rerank-informed document admission on a fresh TRAIN sample of 30 cases. G1 admitted the first five unique documents by frozen Dense order; G2-A admitted the first five unique documents by one shared global rerank over the same Dense Top100. G2 changed no downstream document expansion or evidence-selection contract.
+
+| Metric | G1 | G2-A |
+| --- | ---: | ---: |
+| COMPLETE | 19 | 19 |
+| PARTIAL | 2 | 1 |
+| INSUFFICIENT | 9 | 10 |
+| Macro claim coverage | 0.666667 | 0.650000 |
+| Pairwise wins / ties / losses | - | 2 / 25 / 3 |
+| Catastrophic regressions | - | 2 |
+
+Final decision: **NO_GO**. E1 remains the reference policy; G1 and G2-A remain experimental NO_GO branches. G2-A is not promoted over E1. This was a fresh TRAIN development experiment, not frozen DEV validation. It does not establish generation accuracy uplift or production latency/cost improvement, and it does not show that global reranking is generally harmful. It only rejects this specific rerank-informed five-document admission policy.
+
+The detailed post-hoc, non-confirmatory movement analysis is in [G2 Rerank-Informed Admission Post-Hoc Forensic Analysis](reports/g2_rerank_informed_admission/post_hoc_forensic_analysis.md). The forensic report records the Task 7/8 execution deviations and confirms that no judgment, analytical logic, or gate logic changed after unblinding.
+
 ---
 
 ## 8. Leakage Rules
@@ -350,7 +367,13 @@ G1 document-local evidence experiment
         ↓
 aggregate gain + catastrophic gate failure → NO_GO
         ↓
-keep E1 reference; preserve G1 as experimental candidate
+G2-A rerank-informed 5-document admission
+        ↓
+2 wins / 25 ties / 3 losses + 2 catastrophic regressions
+        ↓
+NO_GO
+        ↓
+keep E1 reference; retain G1/G2-A as experimental evidence
 ```
 
 The value of this lineage is not that every experiment wins. The value is that each result determines the next engineering question without resetting the corpus, benchmark, or evaluation contract.
@@ -375,6 +398,8 @@ experiments/evals/
 │   └── g1_document_local/
 │       ├── evidence_sufficiency_30case_preregistration_v1_1.json
 │       └── final_decision.md
+│   └── g2_rerank_informed_admission/
+│       └── post_hoc_forensic_analysis.md
 ├── eval_techqa_generation.py
 ├── eval_techqa_hybrid_rerank.py
 └── rerankers/
@@ -395,6 +420,7 @@ Current claims are intentionally bounded:
 - Hybrid / RRF / reranking experiments remain offline evaluation evidence unless explicitly promoted into serving;
 - evidence-level audit is diagnostic and does not replace official document metrics;
 - G1 improved evidence sufficiency in its frozen conditional 30-case experiment but failed its preregistered catastrophic-regression gate and therefore does not replace E1;
+- G2-A rerank-informed five-document admission failed its preregistered gates and does not replace E1; its five-case movement analysis is post-hoc diagnostic evidence only;
 - generation uplift is not claimed before frozen generation evaluation is complete;
 - multi-source / conflict-resolution / autonomous Agentic RAG capability is not claimed by this benchmark.
 

--- a/experiments/evals/eval_techqa_g2_admission.py
+++ b/experiments/evals/eval_techqa_g2_admission.py
@@ -67,54 +67,50 @@ def run_g1_g2_admission_comparison(
     dense_ranked_chunks: Sequence[G0RetrievedChunk],
     *,
     shared_global_rerank: RerankResult,
-    candidate_document_limit: int,
     load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
-    candidate_pool_max_chunks: int,
     merged_reranker: Callable[..., Any],
-    evidence_limit: int,
-    max_context_chunks: int,
 ) -> G1G2AdmissionComparison:
     """Compare G1 and G2 document admission with identical downstream steps."""
     dense_ranked = tuple(dense_ranked_chunks)
     g1_candidate_document_ids = select_candidate_document_ids(
         dense_ranked,
-        limit=candidate_document_limit,
+        limit=5,
     )
     g2_candidate_document_ids = select_rerank_informed_document_ids(
         shared_global_rerank,
-        limit=candidate_document_limit,
+        limit=5,
     )
 
     g1_candidate_pool = build_document_local_candidate_pool(
         g1_candidate_document_ids,
         load_document_chunks=load_document_chunks,
-        max_chunks=candidate_pool_max_chunks,
+        max_chunks=500,
     )
     g1_selected_evidence = select_document_local_evidence(
         question,
         g1_candidate_pool,
         reranker=merged_reranker,
-        limit=evidence_limit,
+        limit=16,
     )
     g1_context = assemble_selected_evidence_context(
         g1_selected_evidence,
-        max_context_chunks=max_context_chunks,
+        max_context_chunks=16,
     )
 
     g2_candidate_pool = build_document_local_candidate_pool(
         g2_candidate_document_ids,
         load_document_chunks=load_document_chunks,
-        max_chunks=candidate_pool_max_chunks,
+        max_chunks=500,
     )
     g2_selected_evidence = select_document_local_evidence(
         question,
         g2_candidate_pool,
         reranker=merged_reranker,
-        limit=evidence_limit,
+        limit=16,
     )
     g2_context = assemble_selected_evidence_context(
         g2_selected_evidence,
-        max_context_chunks=max_context_chunks,
+        max_context_chunks=16,
     )
 
     return G1G2AdmissionComparison(

--- a/experiments/evals/eval_techqa_g2_admission.py
+++ b/experiments/evals/eval_techqa_g2_admission.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+import hashlib
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -11,7 +12,12 @@ from experiments.evals.eval_techqa_generation import (
     select_candidate_document_ids,
     select_document_local_evidence,
 )
+from experiments.evals.adapters.techqa import TechQAGenerationCase
 from experiments.evals.rerankers.qwen3_reranker import RerankResult
+
+
+G2_SAMPLE_SEED = "techqa-g2-rerank-informed-admission-v1"
+G2_SAMPLE_SIZE = 30
 
 
 @dataclass(frozen=True)
@@ -34,6 +40,56 @@ class G1G2AdmissionComparison:
     g2_candidate_document_ids: tuple[str, ...]
     g1_context: tuple[G0RetrievedChunk, ...]
     g2_context: tuple[G0RetrievedChunk, ...]
+
+
+def select_g2_preregistered_cases(
+    cases: Sequence[TechQAGenerationCase],
+    *,
+    e0_trace_by_question_id: Mapping[str, Sequence[G0RetrievedChunk]],
+    relevant_document_by_question_id: Mapping[str, str],
+    excluded_question_ids: Collection[str],
+    seed: str = G2_SAMPLE_SEED,
+    sample_size: int = G2_SAMPLE_SIZE,
+) -> tuple[str, ...]:
+    """Select fresh, eligible G2 cases with the frozen deterministic order."""
+    if sample_size <= 0:
+        raise ValueError("sample_size must be positive")
+
+    excluded = set(excluded_question_ids)
+    eligible_question_ids: list[str] = []
+    for case in cases:
+        question_id = case.question_id
+        trace = e0_trace_by_question_id.get(question_id)
+        relevant_document_id = relevant_document_by_question_id.get(question_id)
+        if (
+            question_id in excluded
+            or case.split != "train"
+            or not question_id.startswith("TRAIN_")
+            or not case.answerable
+            or not trace
+            or relevant_document_id is None
+            or not any(
+                chunk.document_id == relevant_document_id for chunk in trace
+            )
+        ):
+            continue
+        eligible_question_ids.append(question_id)
+
+    ordered_question_ids = sorted(
+        eligible_question_ids,
+        key=lambda question_id: (
+            hashlib.sha256(
+                f"{seed}:{question_id}".encode("utf-8")
+            ).hexdigest(),
+            question_id,
+        ),
+    )
+    if len(ordered_question_ids) < sample_size:
+        raise ValueError(
+            "Insufficient eligible G2 preregistration cases: "
+            f"required={sample_size}, actual={len(ordered_question_ids)}"
+        )
+    return tuple(ordered_question_ids[:sample_size])
 
 
 def select_rerank_informed_document_ids(

--- a/experiments/evals/eval_techqa_g2_admission.py
+++ b/experiments/evals/eval_techqa_g2_admission.py
@@ -8,6 +8,7 @@ from experiments.evals.eval_techqa_generation import (
     G0RetrievedChunk,
     assemble_selected_evidence_context,
     build_document_local_candidate_pool,
+    select_candidate_document_ids,
     select_document_local_evidence,
 )
 from experiments.evals.rerankers.qwen3_reranker import RerankResult
@@ -23,6 +24,16 @@ class G2AdmissionDiagnostic:
     selected_evidence: tuple[G0RetrievedChunk, ...]
     final_context: tuple[G0RetrievedChunk, ...]
     merged_rerank_invocations: int
+
+
+@dataclass(frozen=True)
+class G1G2AdmissionComparison:
+    question_id: str
+    dense_candidate_chunk_ids: tuple[str, ...]
+    g1_candidate_document_ids: tuple[str, ...]
+    g2_candidate_document_ids: tuple[str, ...]
+    g1_context: tuple[G0RetrievedChunk, ...]
+    g2_context: tuple[G0RetrievedChunk, ...]
 
 
 def select_rerank_informed_document_ids(
@@ -48,6 +59,72 @@ def select_rerank_informed_document_ids(
             break
 
     return tuple(selected)
+
+
+def run_g1_g2_admission_comparison(
+    question_id: str,
+    question: str,
+    dense_ranked_chunks: Sequence[G0RetrievedChunk],
+    *,
+    shared_global_rerank: RerankResult,
+    candidate_document_limit: int,
+    load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
+    candidate_pool_max_chunks: int,
+    merged_reranker: Callable[..., Any],
+    evidence_limit: int,
+    max_context_chunks: int,
+) -> G1G2AdmissionComparison:
+    """Compare G1 and G2 document admission with identical downstream steps."""
+    dense_ranked = tuple(dense_ranked_chunks)
+    g1_candidate_document_ids = select_candidate_document_ids(
+        dense_ranked,
+        limit=candidate_document_limit,
+    )
+    g2_candidate_document_ids = select_rerank_informed_document_ids(
+        shared_global_rerank,
+        limit=candidate_document_limit,
+    )
+
+    g1_candidate_pool = build_document_local_candidate_pool(
+        g1_candidate_document_ids,
+        load_document_chunks=load_document_chunks,
+        max_chunks=candidate_pool_max_chunks,
+    )
+    g1_selected_evidence = select_document_local_evidence(
+        question,
+        g1_candidate_pool,
+        reranker=merged_reranker,
+        limit=evidence_limit,
+    )
+    g1_context = assemble_selected_evidence_context(
+        g1_selected_evidence,
+        max_context_chunks=max_context_chunks,
+    )
+
+    g2_candidate_pool = build_document_local_candidate_pool(
+        g2_candidate_document_ids,
+        load_document_chunks=load_document_chunks,
+        max_chunks=candidate_pool_max_chunks,
+    )
+    g2_selected_evidence = select_document_local_evidence(
+        question,
+        g2_candidate_pool,
+        reranker=merged_reranker,
+        limit=evidence_limit,
+    )
+    g2_context = assemble_selected_evidence_context(
+        g2_selected_evidence,
+        max_context_chunks=max_context_chunks,
+    )
+
+    return G1G2AdmissionComparison(
+        question_id=question_id,
+        dense_candidate_chunk_ids=tuple(chunk.chunk_id for chunk in dense_ranked),
+        g1_candidate_document_ids=g1_candidate_document_ids,
+        g2_candidate_document_ids=g2_candidate_document_ids,
+        g1_context=g1_context,
+        g2_context=g2_context,
+    )
 
 
 def run_g2_admission_diagnostic(

--- a/experiments/evals/eval_techqa_g2_admission.py
+++ b/experiments/evals/eval_techqa_g2_admission.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from experiments.evals.eval_techqa_generation import (
@@ -18,6 +20,120 @@ from experiments.evals.rerankers.qwen3_reranker import RerankResult
 
 G2_SAMPLE_SEED = "techqa-g2-rerank-informed-admission-v1"
 G2_SAMPLE_SIZE = 30
+
+
+def run_offline_admission_preflight(
+    *,
+    e0_trace_by_question_id: Mapping[str, Sequence[G0RetrievedChunk]],
+    load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
+    shared_rerank_by_question_id: Mapping[str, RerankResult],
+    merged_reranks_by_question_id: Mapping[str, Mapping[str, RerankResult]],
+    output_path: Path | None = None,
+) -> dict[str, Any]:
+    """Check frozen inputs using data-only rerank replays; no provider defaults.
+
+    The caller supplies a frozen corpus loader and the preregistered E0 subset.
+    Fake replay scores exercise mechanics only, never evidence quality. Output
+    contains canonical identities and descriptive capacities, not tuning advice.
+    """
+    if not e0_trace_by_question_id:
+        raise ValueError("preflight requires at least one frozen case")
+    cases: list[dict[str, Any]] = []
+    capacities: dict[str, Any] = {}
+
+    def checked_loader(document_id: str) -> tuple[G0RetrievedChunk, ...]:
+        chunks = tuple(load_document_chunks(document_id))
+        if any(chunk.document_id != document_id for chunk in chunks):
+            raise ValueError(f"loaded chunk outside requested document {document_id!r}")
+        return chunks
+
+    for question_id in sorted(e0_trace_by_question_id):
+        dense = tuple(e0_trace_by_question_id[question_id])
+        dense_ids = [chunk.chunk_id for chunk in dense]
+        if len(dense) != 100 or len(set(dense_ids)) != 100:
+            raise ValueError(f"{question_id}: Dense Top100 must contain 100 unique chunks")
+        dense_documents = {chunk.chunk_id: chunk.document_id for chunk in dense}
+        shared = shared_rerank_by_question_id[question_id]
+        shared_ids = [item.chunk_id for item in shared.results]
+        if (
+            len(shared_ids) != 100
+            or set(shared_ids) != set(dense_ids)
+            or any(dense_documents.get(item.chunk_id) != item.document_id for item in shared.results)
+        ):
+            raise ValueError(f"{question_id}: shared replay must preserve Dense Top100 identity")
+
+        # Reorder existing replay rows in memory to express G1's Dense admission.
+        # This is not another rerank invocation; both arms use the same diagnostic.
+        shared_by_id = {item.chunk_id: item for item in shared.results}
+        dense_admission = RerankResult(
+            results=tuple(shared_by_id[chunk_id] for chunk_id in dense_ids),
+            request_id="offline-dense-admission",
+            total_tokens=0,
+        )
+        case: dict[str, Any] = {"question_id": question_id, "dense_chunk_ids": dense_ids}
+        capacities[question_id] = {}
+        for arm, admission in (("g1", dense_admission), ("g2", shared)):
+            merged = merged_reranks_by_question_id[question_id][arm]
+
+            def replay_merged(_question: str, candidates: Sequence[Any]) -> RerankResult:
+                candidate_documents = {item.chunk_id: item.document_id for item in candidates}
+                replay_ids = [item.chunk_id for item in merged.results]
+                if (
+                    len(replay_ids) != len(set(replay_ids))
+                    or any(
+                        candidate_documents.get(item.chunk_id) != item.document_id
+                        for item in merged.results
+                    )
+                ):
+                    raise ValueError(f"{question_id}/{arm}: invalid merged replay identity")
+                return merged
+
+            diagnostic = run_g2_admission_diagnostic(
+                question_id,
+                "",  # Replay is data-only and does not inspect query text.
+                dense,
+                shared_global_rerank=admission,
+                candidate_document_limit=5,
+                load_document_chunks=checked_loader,
+                candidate_pool_max_chunks=500,
+                merged_reranker=replay_merged,
+                evidence_limit=16,
+                max_context_chunks=16,
+            )
+            expected_docs = tuple(dict.fromkeys(item.document_id for item in admission.results))[:5]
+            if diagnostic.dense_ranked_chunks != dense or diagnostic.candidate_document_ids != expected_docs:
+                raise ValueError(f"{question_id}/{arm}: frozen admission identity changed")
+            for label, chunks, limit in (
+                ("candidate", diagnostic.candidate_pool, 500),
+                ("context", diagnostic.final_context, 16),
+            ):
+                ids = [chunk.chunk_id for chunk in chunks]
+                if (
+                    len(ids) > limit
+                    or len(ids) != len(set(ids))
+                    or any(chunk.document_id not in expected_docs for chunk in chunks)
+                ):
+                    raise ValueError(f"{question_id}/{arm}: invalid {label} capacity or identity")
+            if diagnostic.merged_rerank_invocations != bool(diagnostic.candidate_pool):
+                raise ValueError(f"{question_id}/{arm}: unexpected merged replay invocation count")
+            case[f"{arm}_admitted_doc_ids"] = list(diagnostic.candidate_document_ids)
+            case[f"{arm}_candidate_chunk_ids"] = [chunk.chunk_id for chunk in diagnostic.candidate_pool]
+            capacities[question_id][arm] = {
+                "candidate_chunks": len(diagnostic.candidate_pool),
+                "context_chunks": len(diagnostic.final_context),
+            }
+        cases.append(case)
+
+    canonical = json.dumps(cases, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    summary = {
+        "mode": "offline_replay_preflight",
+        "cases": cases,
+        "capacity_by_question_id": capacities,
+        "fingerprint_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+    }
+    if output_path is not None:
+        output_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return summary
 
 
 @dataclass(frozen=True)

--- a/experiments/evals/eval_techqa_g2_admission.py
+++ b/experiments/evals/eval_techqa_g2_admission.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from experiments.evals.rerankers.qwen3_reranker import RerankResult
+
+
+def select_rerank_informed_document_ids(
+    rerank_result: RerankResult,
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    """Select the first unique document IDs in shared global rerank order."""
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    selected: list[str] = []
+    seen: set[str] = set()
+
+    for candidate in rerank_result.results:
+        document_id = candidate.document_id
+        if document_id in seen:
+            continue
+
+        seen.add(document_id)
+        selected.append(document_id)
+        if len(selected) >= limit:
+            break
+
+    return tuple(selected)

--- a/experiments/evals/eval_techqa_g2_admission.py
+++ b/experiments/evals/eval_techqa_g2_admission.py
@@ -1,6 +1,28 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from experiments.evals.eval_techqa_generation import (
+    G0RetrievedChunk,
+    assemble_selected_evidence_context,
+    build_document_local_candidate_pool,
+    select_document_local_evidence,
+)
 from experiments.evals.rerankers.qwen3_reranker import RerankResult
+
+
+@dataclass(frozen=True)
+class G2AdmissionDiagnostic:
+    question_id: str
+    question: str
+    dense_ranked_chunks: tuple[G0RetrievedChunk, ...]
+    candidate_document_ids: tuple[str, ...]
+    candidate_pool: tuple[G0RetrievedChunk, ...]
+    selected_evidence: tuple[G0RetrievedChunk, ...]
+    final_context: tuple[G0RetrievedChunk, ...]
+    merged_rerank_invocations: int
 
 
 def select_rerank_informed_document_ids(
@@ -26,3 +48,69 @@ def select_rerank_informed_document_ids(
             break
 
     return tuple(selected)
+
+
+def run_g2_admission_diagnostic(
+    question_id: str,
+    question: str,
+    dense_ranked_chunks: Sequence[G0RetrievedChunk],
+    *,
+    shared_global_rerank: RerankResult,
+    candidate_document_limit: int,
+    load_document_chunks: Callable[[str], Sequence[G0RetrievedChunk]],
+    candidate_pool_max_chunks: int,
+    merged_reranker: Callable[..., Any],
+    evidence_limit: int,
+    max_context_chunks: int,
+) -> G2AdmissionDiagnostic:
+    """Run the offline G2 path using an already-computed global rerank result."""
+    if any(
+        limit <= 0
+        for limit in (
+            candidate_document_limit,
+            candidate_pool_max_chunks,
+            evidence_limit,
+            max_context_chunks,
+        )
+    ):
+        raise ValueError("all diagnostic limits must be positive")
+
+    dense_ranked = tuple(dense_ranked_chunks)
+    candidate_document_ids = select_rerank_informed_document_ids(
+        shared_global_rerank,
+        limit=candidate_document_limit,
+    )
+    candidate_pool = build_document_local_candidate_pool(
+        candidate_document_ids,
+        load_document_chunks=load_document_chunks,
+        max_chunks=candidate_pool_max_chunks,
+    )
+
+    merged_rerank_invocations = 0
+
+    def tracked_merged_reranker(*args: Any) -> Any:
+        nonlocal merged_rerank_invocations
+        merged_rerank_invocations += 1
+        return merged_reranker(*args)
+
+    selected_evidence = select_document_local_evidence(
+        question,
+        candidate_pool,
+        reranker=tracked_merged_reranker,
+        limit=evidence_limit,
+    )
+    final_context = assemble_selected_evidence_context(
+        selected_evidence,
+        max_context_chunks=max_context_chunks,
+    )
+
+    return G2AdmissionDiagnostic(
+        question_id=question_id,
+        question=question,
+        dense_ranked_chunks=dense_ranked,
+        candidate_document_ids=candidate_document_ids,
+        candidate_pool=candidate_pool,
+        selected_evidence=selected_evidence,
+        final_context=final_context,
+        merged_rerank_invocations=merged_rerank_invocations,
+    )

--- a/experiments/evals/reports/g2_rerank_informed_admission/README.md
+++ b/experiments/evals/reports/g2_rerank_informed_admission/README.md
@@ -1,0 +1,57 @@
+# G2-A rerank-informed document admission
+
+G1 remains the reference and evaluated predecessor. G2-A is an offline experiment,
+not serving code. It changes only document-admission ranking: G1 admits the first
+five unique documents in frozen E0 Dense Top100 order; G2-A admits the first five
+in one shared global rerank of those same 100 chunks. Both arms retain the same
+document expansion, 500-chunk pool cap, one merged document-local rerank,
+Top16 evidence selection, and 16-chunk final context cap. Continuity, sibling
+expansion, extra rerank passes, query rewriting, tuning, and serving changes remain
+explicitly out of scope.
+
+The previous 30 G1 cases are excluded from confirmation. The fresh 30 IDs,
+94-ID exclusion-union hash, budgets, and GO/NO-GO gates are frozen in
+[preregistration_v1.json](preregistration_v1.json). No resampling or threshold
+tuning may follow inspection of preflight capacities or later outcomes.
+
+## Offline preflight
+
+`run_offline_admission_preflight` in `experiments/evals/eval_techqa_g2_admission.py`
+accepts a mapping of frozen E0 traces (`question_id` to `G0RetrievedChunk` sequence),
+a frozen corpus chunk loader, a mapping of precomputed shared `RerankResult`s,
+and a mapping of precomputed `g1`/`g2` merged `RerankResult`s per question ID.
+There is no provider callback or credential argument. The caller must use the
+preregistered 30-case subset and a loader backed by the frozen local corpus;
+the function deliberately does not load datasets or run retrieval itself.
+
+The existing diagnostic executes once per arm, with budgets 5/500/16/16. G1's
+admission replay is an in-memory reordering into Dense order, not a provider pass.
+Both merged results are replayed in memory. Shared replay must preserve all 100
+Dense chunk identities and document associations. Invalid loaded/replayed IDs,
+duplicate replay IDs, capacity violations, and empty case sets fail the preflight.
+Loaded duplicate chunks are deduplicated by the existing G1 helper.
+
+The returned JSON-compatible summary can be persisted with `output_path=Path(...)`.
+It records descriptive candidate/context counts only, alongside identity fields
+needed for reproducibility. It contains no quality scores, GO decision, or tuning
+recommendations. SHA256 covers the UTF-8 canonical JSON array sorted by question
+ID, with sorted object keys, `ensure_ascii=False`, and separators `(',', ':')`.
+Each case contains exactly `question_id`, `dense_chunk_ids`,
+`g1_admitted_doc_ids`, `g2_admitted_doc_ids`, `g1_candidate_chunk_ids`, and
+`g2_candidate_chunk_ids`; list ordering is preserved. Run twice with identical
+frozen inputs and require equal fingerprints. Fake rerank order demonstrates
+mechanical correctness only and is not evidence of G2 quality or real capacity
+under a provider ranking.
+
+Run local verification with no API credentials:
+
+```powershell
+conda run --no-capture-output -n enterprise-g1-verify python -m pytest tests/test_eval_techqa_g2_admission.py tests/test_generation_eval_runner.py -q
+conda run --no-capture-output -n enterprise-g1-verify ruff check experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+conda run --no-capture-output -n enterprise-g1-verify python -m compileall -q experiments/evals/eval_techqa_g2_admission.py tests/test_eval_techqa_g2_admission.py
+```
+
+Tripwire tests fail on live Dense/Chroma queries, provider global rerank,
+generation, judging, embeddings, or network connections. Paid execution is
+authorized only after preflight passes; it is a separate later task governed by
+the frozen preregistration. Task 5 does not execute paid providers.

--- a/experiments/evals/reports/g2_rerank_informed_admission/post_hoc_forensic_analysis.md
+++ b/experiments/evals/reports/g2_rerank_informed_admission/post_hoc_forensic_analysis.md
@@ -1,0 +1,79 @@
+# G2 Rerank-Informed Admission Post-Hoc Forensic Analysis
+
+## 1. Frozen confirmatory result
+
+The frozen Task 8 result is unchanged and remains the confirmatory record:
+
+| Metric | G1 | G2-A |
+| --- | ---: | ---: |
+| COMPLETE | 19 | 19 |
+| PARTIAL | 2 | 1 |
+| INSUFFICIENT | 9 | 10 |
+| UNRESOLVED | 0 | 0 |
+| Macro claim coverage | 0.666667 | 0.650000 |
+
+Pairwise result is **2 wins / 25 ties / 3 losses**, including **2 catastrophic regressions**. The final decision is **NO_GO**. The Task 8 result artifact SHA-256 is `8e6e51ca0bc2200987e473058c77fa58293e62be45e5964f94b79eddfe904145`; the canonical SHA-256 is `94c45247dd7399f882ca1cd8bad1c9b5702d7420183b35fbc547531877a886e9`.
+
+This report does not rewrite that result. It is a post-hoc diagnostic over already-frozen local artifacts and is not preregistered confirmatory evidence. No rerank, embedding, generation, or judge calls were made during this analysis.
+
+## 2. Method and causal boundary
+
+The sealed A/B mapping was used to unblind the frozen outcomes. The five movements were then derived mechanically by comparing the frozen G1 and G2 outcome arrays:
+
+- G1 INSUFFICIENT -> G2 COMPLETE: `TRAIN_Q287`, `TRAIN_Q578`
+- G1 COMPLETE -> G2 INSUFFICIENT: `TRAIN_Q090`, `TRAIN_Q500`
+- G1 PARTIAL -> G2 INSUFFICIENT: `TRAIN_Q367`
+
+G2 changes only admission order. G1 takes the first five unique documents in Dense Top100; G2 takes the first five unique documents in the shared global rerank over the same Dense Top100. Document-local expansion, the 500-chunk pool cap, merged rerank, and Top16 selection are otherwise frozen.
+
+## 3. Five movement cases
+
+The `Dense relevant positions` and `global relevant positions` columns are 1-based chunk positions. `G1 docs` and `G2 docs` are the exact first-five admitted document IDs reconstructed from the frozen Dense chunk order and paid `shared_global` rerank, respectively. Pool sizes and document IDs are reconstructed from the complete paid `g1_merged` and `g2_merged` permutations. The following invariants all passed: `dense_preflight_equals_E0`, `g1_pool_docs_equals_g1_admitted`, `g2_pool_docs_equals_g2_admitted`, `g1_top16_docs_within_g1_admitted`, and `g2_top16_docs_within_g2_admitted`.
+
+| Case | Gold document | Dense relevant positions | Global relevant positions | G1 docs / pool | G2 docs / pool | Outcome |
+| --- | --- | --- | --- | --- | --- | --- |
+| `TRAIN_Q287` (`U023`) | `swg27047895.txt` | 20, 58 | 1, 8 | no; `swg1IO23927.txt`, `swg1IO25547.txt`, `swg1IO25431.txt`, `swg1IO23565.txt`, `swg1IO23514.txt` / 21 | yes; `swg27047895.txt`, `swg21599801.txt`, `swg21959318.txt`, `swg21903282.txt`, `swg21968904.txt` / 35 | INSUFFICIENT -> COMPLETE |
+| `TRAIN_Q578` (`U059`) | `swg21612222.txt` | 14, 67 | 1, 11 | no; `swg21504129.txt`, `swg21260903.txt`, `swg22004447.txt`, `swg22006446.txt`, `swg1IT12043.txt` / 27 | yes; `swg21612222.txt`, `swg22006446.txt`, `swg21260903.txt`, `swg21902484.txt`, `swg1IT09552.txt` / 27 | INSUFFICIENT -> COMPLETE |
+| `TRAIN_Q090` (`U006`) | `swg24044840.txt` | 2, 11 | 11, 14 | yes; `swg24041994.txt`, `swg24044840.txt`, `swg21692150.txt`, `swg21974112.txt`, `swg21687624.txt` / 102 | no; `swg21692150.txt`, `swg21687624.txt`, `swg21616976.txt`, `swg1IZ51168.txt`, `swg21965628.txt` / 16 | COMPLETE -> INSUFFICIENT |
+| `TRAIN_Q500` (`U010`) | `swg21631488.txt` | 3 | 8 | yes; `swg27024104.txt`, `swg21631488.txt`, `swg21594791.txt`, `swg27023623.txt`, `swg21686987.txt` / 16 | no; `swg21594791.txt`, `swg27023623.txt`, `swg21608749.txt`, `swg21607198.txt`, `swg27023851.txt` / 22 | COMPLETE -> INSUFFICIENT |
+| `TRAIN_Q367` (`U055`) | `swg21968549.txt` | 15 | 9 | no; `swg21903444.txt`, `swg21973739.txt`, `swg21976161.txt`, `swg21503678.txt`, `swg21968904.txt` / 25 | no; `swg21503322.txt`, `swg21976161.txt`, `swg21973739.txt`, `swg21503678.txt`, `swg21632650.txt` / 25 | PARTIAL -> INSUFFICIENT |
+
+For `TRAIN_Q287` and `TRAIN_Q578`, the relevant document is absent from G1's admitted set and present in G2's. The G2 merged Top16 starts with `swg27047895.txt_chunk_6` and `swg21612222.txt_chunk_1`, respectively; those are the rescued relevant chunks. For `TRAIN_Q090`, G1's Top16 contains `swg24044840.txt_chunk_13` and `swg24044840.txt_chunk_14`, while G2 cannot select either because the relevant document is excluded at admission. For `TRAIN_Q500`, the gold document is `swg21631488.txt`: its Dense rank is 3 and global rerank rank is 8. G1's Top16 includes `swg21631488.txt_chunk_0`, while G2's selected Top16 comes from the changed 22-chunk pool and contains no `swg21631488.txt` chunk.
+
+`TRAIN_Q367` is the important control against over-attributing every movement to admission rescue or exclusion: both arms exclude the gold document. The first merged selections are still different: G1 starts with `swg21976161.txt_chunk_1`, `swg21973739.txt_chunk_12`, and `swg21503678.txt_chunk_2`; G2 starts with `swg21976161.txt_chunk_1`, `swg21503322.txt_chunk_1`, and `swg21973739.txt_chunk_12`.
+
+Material claims and blinded-review outcomes were preserved from the frozen artifacts. `TRAIN_Q287` moved from 0/1 to 1/1 covered claims; `TRAIN_Q578` moved from 0/2 to 2/2; `TRAIN_Q090` moved from 1/1 to 0/1; `TRAIN_Q500` moved from 1/1 to 0/1; and `TRAIN_Q367` moved from 1/2 to 0/2.
+
+## 4. First divergence and mechanism findings
+
+| Case | First G1/G2 divergence | Mechanism classification |
+| --- | --- | --- |
+| `TRAIN_Q287` | Document admission | Relevant document rescued: global rerank moved its Dense-rank-20/58 chunks to global ranks 1/8, bringing it into G2's five-document budget. |
+| `TRAIN_Q578` | Document admission | Relevant document rescued: its Dense chunks at 14/67 became global ranks 1/11, so G2 admitted the document and G1 did not. |
+| `TRAIN_Q090` | Document admission | Relevant document displaced: despite Dense ranks 2/11, global admission selected five other documents and permanently removed the useful G1 document. |
+| `TRAIN_Q500` | Document admission | Relevant document displaced: G1 admitted the gold document; global admission changed the five-document set, after which the gold document had no downstream opportunity. |
+| `TRAIN_Q367` | Document-admission-set composition | Both arms excluded the gold document, but their admitted document sets differ. That first admission-set divergence changes candidate-pool composition and then downstream merged Top16 selection. |
+
+The two wins are gold-document admission rescues. The two catastrophic regressions are gold-document displacements under the rerank-informed five-document budget. `TRAIN_Q367` also first diverges at admission-set composition: both arms miss the gold document, but their different admitted sets change the downstream candidate pool and selected evidence. There is not enough evidence here to claim independent merged-rerank instability.
+
+## 5. Decision questions
+
+**Q1.** Yes. Both G2 wins are cases where Dense admission excluded the relevant document and global rerank admission rescued it.
+
+**Q2.** Yes. Both catastrophic regressions are cases where G1 admitted the relevant/useful document but the global-rerank five-document budget did not.
+
+**Q3.** For `TRAIN_Q367`, both arms miss the gold document. The first divergence is document-admission-set composition; that changes the candidate pool and downstream selected evidence.
+
+**Q4.** **A. Admission ranking instability is the dominant mechanism, with the fixed five-document budget acting as an amplifier.** Four of five movements directly involve gold-document rescue or displacement, and `TRAIN_Q367` also first diverges at admission-set composition. These cases do not establish independent merged-rerank instability or evidence continuity as the cause.
+
+**Q5.** **MAYBE — mechanism is suggestive but insufficient; gather broader diagnostic evidence first.** The rescue/displacement pattern is strong enough to motivate diagnostics, but five post-hoc cases are not enough to justify designing or preregistering G3. No G3 is designed or implemented here.
+
+## 6. What this does not establish
+
+This was a fresh TRAIN development experiment, not frozen DEV validation. It does not establish generation accuracy uplift, production latency/cost improvement, or that global reranking is generally harmful. It only rejects this specific rerank-informed five-document admission policy. The forensic findings are post-hoc and must not be promoted to confirmatory evidence.
+
+Task 7/8 execution deviations are recorded here for audit completeness: the reviewer child high-level file-read workflow stalled; explicit Python byte I/O was adopted before any judgments were observed; no judgment or rule changed after unblinding; Task 8 required one controlled mapping reread after final-attestation Python boolean literals used `false` instead of `False`; the actual correction was four identical `false -> False` repairs in final-attestation fields; and no analytical or gate logic changed.
+
+## 7. Recommendation
+
+Keep E1 reference behavior unchanged and record G1 and G2-A as experimental **NO_GO** branches. Before considering another experiment, gather broader offline diagnostics over the frozen traces: admission-miss frequency, relevant-document displacement frequency, candidate-pool overlap, and the rate at which merged Top16 selection changes after admission-set changes. Any future experiment would require a new preregistration and must not use this post-hoc table as confirmatory evidence.

--- a/experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json
+++ b/experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json
@@ -63,8 +63,8 @@
     "g1_selected_case_count": 30,
     "manual_evidence_label_question_id_count": 60,
     "exclusion_count_after_union": 94,
-    "sorted_exclusion_list_sha256": "0ca47005b546a2c89ff711eceaf365425aa6535a16d0d9f108196c8c1c505904",
-    "hash_serialization": "UTF-8 encoding of '\\n'.join(sorted(unique_question_ids))",
+    "sorted_exclusion_list_sha256": "58f9b7d85d92d6fa20602d6fc9bddeee2f542e6bfb4e75dbc722e448c38f1cab",
+    "hash_serialization": "UTF-8 bytes of the sorted unique question IDs joined by one actual LF separator byte (0x0A), with no leading or trailing separator",
     "policy": "Apply the union before eligibility hashing and sampling."
   },
   "g1_contract": {

--- a/experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json
+++ b/experiments/evals/reports/g2_rerank_informed_admission/preregistration_v1.json
@@ -1,0 +1,133 @@
+{
+  "experiment_id": "techqa_g2_rerank_informed_admission_v1",
+  "artifact_state": "PREREGISTRATION_BEFORE_PAID_EXECUTION",
+  "baseline_commit": "7caf1a1245bdc73698c9fb218c863425ae3b7f8f",
+  "sample_seed": "techqa-g2-rerank-informed-admission-v1",
+  "sample_size": 30,
+  "selected_case_ids": [
+    "TRAIN_Q489",
+    "TRAIN_Q277",
+    "TRAIN_Q090",
+    "TRAIN_Q393",
+    "TRAIN_Q500",
+    "TRAIN_Q570",
+    "TRAIN_Q291",
+    "TRAIN_Q042",
+    "TRAIN_Q302",
+    "TRAIN_Q270",
+    "TRAIN_Q028",
+    "TRAIN_Q287",
+    "TRAIN_Q172",
+    "TRAIN_Q158",
+    "TRAIN_Q193",
+    "TRAIN_Q543",
+    "TRAIN_Q232",
+    "TRAIN_Q321",
+    "TRAIN_Q488",
+    "TRAIN_Q537",
+    "TRAIN_Q240",
+    "TRAIN_Q442",
+    "TRAIN_Q431",
+    "TRAIN_Q372",
+    "TRAIN_Q278",
+    "TRAIN_Q267",
+    "TRAIN_Q378",
+    "TRAIN_Q367",
+    "TRAIN_Q085",
+    "TRAIN_Q578"
+  ],
+  "selection_algorithm": "For every eligible question_id, compute sha256(sample_seed + ':' + question_id).hexdigest(); sort ascending by (hash, question_id); select the first 30. No shuffle, replacement, resampling, outcome-based exclusion, or parameter change is permitted after this artifact is frozen.",
+  "eligibility_rule": {
+    "question_id_prefix": "TRAIN_",
+    "split": "train",
+    "answerable": true,
+    "e0_trace_required": true,
+    "formal_relevant_document_count": 1,
+    "formal_relevant_document_boundary": "At least one chunk from the sole formal relevant document must appear somewhere in the frozen historical E0 Dense Top100; Dense first5 membership is not required."
+  },
+  "exclusion_contract": {
+    "sources": {
+      "historical_g0_12_case_pilot": {
+        "selector": "experiments/evals/eval_techqa_generation.py:select_g0_train_pilot_cases",
+        "seed": "techqa-g0-generation-pilot-v1",
+        "ids": [
+          "TRAIN_Q055", "TRAIN_Q102", "TRAIN_Q130", "TRAIN_Q294",
+          "TRAIN_Q299", "TRAIN_Q335", "TRAIN_Q418", "TRAIN_Q427",
+          "TRAIN_Q447", "TRAIN_Q485", "TRAIN_Q542", "TRAIN_Q572"
+        ]
+      },
+      "g1_preregistration": "experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json:selected_case_ids",
+      "manual_evidence_labels": "experiments/evals/reports/r1_evidence_audit/evidence_labels.jsonl:question_id",
+      "explicit_g1_forensic_ids": ["TRAIN_Q346", "TRAIN_Q492"]
+    },
+    "g1_selected_case_count": 30,
+    "manual_evidence_label_question_id_count": 60,
+    "exclusion_count_after_union": 94,
+    "sorted_exclusion_list_sha256": "0ca47005b546a2c89ff711eceaf365425aa6535a16d0d9f108196c8c1c505904",
+    "hash_serialization": "UTF-8 encoding of '\\n'.join(sorted(unique_question_ids))",
+    "policy": "Apply the union before eligibility hashing and sampling."
+  },
+  "g1_contract": {
+    "document_admission_order": "frozen historical E0 Dense order",
+    "candidate_document_selection": "first 5 unique document IDs",
+    "candidate_pool_max_chunks": 500,
+    "merged_document_local_rerank_calls_per_case": 1,
+    "evidence_limit": 16,
+    "max_context_chunks": 16
+  },
+  "g2_contract": {
+    "document_admission_order": "one shared global rerank order over the same frozen historical E0 Dense Top100",
+    "candidate_document_selection": "first 5 unique document IDs",
+    "candidate_pool_max_chunks": 500,
+    "merged_document_local_rerank_calls_per_case": 1,
+    "evidence_limit": 16,
+    "max_context_chunks": 16,
+    "one_variable_statement": "Only document-admission order differs from G1; all downstream document expansion, merged rerank, Top16 evidence selection, context cap, model, and instruction remain fixed."
+  },
+  "rerank_contract": {
+    "model": "qwen3-rerank",
+    "instruction": "Rank the candidate passages by relevance to resolving the technical support query.",
+    "global_input": "frozen historical E0 Dense Top100",
+    "same_instruction_for_global_and_merged_reranks": true,
+    "forbidden": [
+      "prompt tuning",
+      "method-specific instruction",
+      "query rewrite",
+      "alternate reranker",
+      "per-document reranking",
+      "second-pass rerank"
+    ]
+  },
+  "provider_call_budget": {
+    "shared_global_calls_per_case": 1,
+    "g1_merged_calls_per_case": 1,
+    "g2_merged_calls_per_case": 1,
+    "max_real_rerank_calls": 90,
+    "max_embedding_calls": 0,
+    "max_generation_calls": 0,
+    "max_judge_calls": 0,
+    "provider_failure_policy": "Any provider failure stops the run; no retry, candidate truncation, case replacement, or model change is allowed."
+  },
+  "go_no_go_rule": {
+    "GO_TO_NEXT_STAGE": "yes only if every gate is satisfied",
+    "gates": [
+      "all 30 cases execute under the frozen provider/capacity contract",
+      "unresolved evidence-review count is 0",
+      "G2_complete_count >= G1_complete_count",
+      "G2_insufficient_count <= G1_insufficient_count",
+      "G2_macro_claim_coverage >= G1_macro_claim_coverage",
+      "pairwise ordinal G2_wins > G2_losses",
+      "catastrophic regression count is 0, where catastrophic regression is G1=COMPLETE && G2=INSUFFICIENT"
+    ],
+    "all_contexts_tie": "NO_GO because the strict G2_wins > G2_losses gate is not met.",
+    "go_scope": "A GO authorizes only a next design/evaluation stage; it does not establish production accuracy, latency improvement, statistical significance, or serving-path promotion."
+  },
+  "source_artifacts": {
+    "generation_cases": "experiments/evals/datasets/techqa/manifest.json",
+    "historical_e0_dense_trace": "experiments/evals/reports/e0_dense/train_results.jsonl",
+    "g1_preregistration": "experiments/evals/reports/g1_document_local/evidence_sufficiency_30case_preregistration_v1_1.json",
+    "manual_evidence_labels": "experiments/evals/reports/r1_evidence_audit/evidence_labels.jsonl",
+    "g1_forensics": "experiments/evals/reports/g1_document_local/final_decision.md"
+  },
+  "experiment_results": "intentionally absent"
+}

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+
+import pytest
+
+from experiments.evals.rerankers.qwen3_reranker import (
+    RerankResult,
+    RerankedCandidate,
+)
+
+
+MODULE_NAME = "experiments.evals.eval_techqa_g2_admission"
+
+
+def _g2_module():
+    spec = importlib.util.find_spec(MODULE_NAME)
+    assert spec is not None, "eval_techqa_g2_admission is not implemented"
+    return importlib.import_module(MODULE_NAME)
+
+
+def _shared_rerank(*document_ids: str) -> RerankResult:
+    return RerankResult(
+        results=tuple(
+            RerankedCandidate(
+                chunk_id=f"chunk-{index}",
+                document_id=document_id,
+                content=f"content-{index}",
+                original_index=index,
+                relevance_score=1.0 - index / 100.0,
+            )
+            for index, document_id in enumerate(document_ids)
+        ),
+        request_id="shared-global-rerank",
+        total_tokens=123,
+    )
+
+
+def test_rerank_informed_admission_uses_first_unique_docs_in_rerank_order():
+    module = _g2_module()
+    selector = getattr(module, "select_rerank_informed_document_ids", None)
+    assert selector is not None, "select_rerank_informed_document_ids is not implemented"
+
+    result = _shared_rerank("D3", "D3", "D1", "D5", "D2", "D4", "D6")
+
+    assert selector(result, limit=5) == ("D3", "D1", "D5", "D2", "D4")
+
+
+def test_rerank_informed_admission_returns_all_unique_docs_when_under_limit():
+    module = _g2_module()
+    selector = getattr(module, "select_rerank_informed_document_ids", None)
+    assert selector is not None, "select_rerank_informed_document_ids is not implemented"
+
+    result = _shared_rerank("D2", "D2", "D1")
+
+    assert selector(result, limit=5) == ("D2", "D1")
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_rerank_informed_admission_requires_positive_limit(limit: int):
+    module = _g2_module()
+    selector = getattr(module, "select_rerank_informed_document_ids", None)
+    assert selector is not None, "select_rerank_informed_document_ids is not implemented"
+
+    with pytest.raises(ValueError, match="limit must be positive"):
+        selector(_shared_rerank("D1"), limit=limit)

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import hashlib
+import json
+import socket
+from dataclasses import replace
 
 import pytest
 
@@ -16,6 +19,181 @@ from experiments.evals.rerankers.qwen3_reranker import (
 
 
 MODULE_NAME = "experiments.evals.eval_techqa_g2_admission"
+
+
+def _preflight_runner():
+    runner = getattr(_g2_module(), "run_offline_admission_preflight", None)
+    assert runner is not None, "offline admission preflight is not implemented"
+    return runner
+
+
+def _replay(chunks):
+    return RerankResult(
+        results=tuple(
+            RerankedCandidate(
+                chunk_id=chunk.chunk_id,
+                document_id=chunk.document_id,
+                content=chunk.content,
+                original_index=index,
+                relevance_score=1.0 - index / 1000,
+            )
+            for index, chunk in enumerate(chunks)
+        ),
+        request_id="offline-fake",
+        total_tokens=0,
+    )
+
+
+def _preflight_inputs():
+    dense = tuple(_chunk(f"dense-{i}", f"D{i // 10}") for i in range(100))
+    corpus = {
+        f"D{i}": tuple(_chunk(f"D{i}-{j}", f"D{i}") for j in range(101))
+        for i in range(10)
+    }
+    # 5 * 101 crosses the frozen cap, independently expected: 4 * 101 + 96.
+    g1_pool = tuple(c for i in range(5) for c in corpus[f"D{i}"])[:500]
+    g2_pool = tuple(c for i in range(9, 4, -1) for c in corpus[f"D{i}"])[:500]
+    return {
+        "e0_trace_by_question_id": {"TRAIN_PREFLIGHT": dense},
+        "load_document_chunks": corpus.__getitem__,
+        "shared_rerank_by_question_id": {"TRAIN_PREFLIGHT": _replay(reversed(dense))},
+        "merged_reranks_by_question_id": {
+            "TRAIN_PREFLIGHT": {"g1": _replay(g1_pool), "g2": _replay(g2_pool)},
+        },
+    }
+
+
+@pytest.fixture
+def offline_tripwires(monkeypatch):
+    def forbidden(*args, **kwargs):
+        pytest.fail("offline preflight attempted live retrieval/provider/generation/judge/embedding/network")
+
+    targets = {
+        "experiments.evals.eval_techqa_generation": (
+            "search_techqa_index", "rerank_candidates", "generate_answer",
+            "judge_techqa_generation", "get_chroma_client", "_default_judge_model",
+        ),
+        "experiments.evals.build_techqa_index": ("search_techqa_index", "embed_texts", "get_chroma_client"),
+        "experiments.evals.rerankers.qwen3_reranker": ("rerank_candidates", "get_rerank_client"),
+        "rag_runtime.query_rag_chroma": ("generate_answer", "get_llm_client", "search_chroma"),
+        "rag_runtime.query_chroma": ("search_chroma", "get_collection"),
+        "rag_runtime.build_rag_index": ("embed_texts",),
+        "experiments.evals.judges.deepeval_dashscope": ("get_llm_client",),
+    }
+    for module_name, names in targets.items():
+        module = importlib.import_module(module_name)
+        for name in names:
+            monkeypatch.setattr(module, name, forbidden)
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    for name in ("DASHSCOPE_API_KEY", "OPENAI_API_KEY", "RERANK_API_KEY", "LLM_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_offline_preflight_preserves_invariants_and_persists_repeatable_fingerprint(
+    offline_tripwires, tmp_path,
+):
+    runner = _preflight_runner()
+    inputs = _preflight_inputs()
+    first_path, second_path = tmp_path / "first.json", tmp_path / "second.json"
+    first = runner(**inputs, output_path=first_path)
+    second = runner(**inputs, output_path=second_path)
+    assert first == second == json.loads(first_path.read_text(encoding="utf-8"))
+    assert first_path.read_bytes() == second_path.read_bytes()
+    case = first["cases"][0]
+    assert case["question_id"] == "TRAIN_PREFLIGHT"
+    assert case["dense_chunk_ids"] == [f"dense-{i}" for i in range(100)]
+    assert case["g1_admitted_doc_ids"] == ["D0", "D1", "D2", "D3", "D4"]
+    assert case["g2_admitted_doc_ids"] == ["D9", "D8", "D7", "D6", "D5"]
+    for arm, first_doc, last_doc in (("g1", "D0", "D4"), ("g2", "D9", "D5")):
+        ids = case[f"{arm}_candidate_chunk_ids"]
+        assert len(ids) == len(set(ids)) == 500
+        assert ids[0] == f"{first_doc}-0"
+        assert ids[-1] == f"{last_doc}-95"
+        assert all(cid.split("-")[0] in case[f"{arm}_admitted_doc_ids"] for cid in ids)
+        capacity = first["capacity_by_question_id"]["TRAIN_PREFLIGHT"][arm]
+        assert capacity == {"candidate_chunks": 500, "context_chunks": 16}
+    canonical = json.dumps(first["cases"], sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    assert first["fingerprint_sha256"] == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@pytest.mark.parametrize("fault", ["short_dense", "duplicate_dense", "missing_shared", "foreign_shared", "wrong_shared_doc", "duplicate_shared"])
+def test_offline_preflight_rejects_invalid_frozen_dense_or_shared_replay_before_loading(fault):
+    runner = _preflight_runner()
+    inputs = _preflight_inputs()
+    qid = "TRAIN_PREFLIGHT"
+    dense = inputs["e0_trace_by_question_id"][qid]
+    shared = inputs["shared_rerank_by_question_id"][qid]
+    if fault == "short_dense":
+        inputs["e0_trace_by_question_id"][qid] = dense[:-1]
+    elif fault == "duplicate_dense":
+        inputs["e0_trace_by_question_id"][qid] = (*dense[:-1], dense[0])
+    elif fault == "missing_shared":
+        inputs["shared_rerank_by_question_id"][qid] = replace(shared, results=shared.results[:-1])
+    else:
+        replacement = {
+            "foreign_shared": replace(shared.results[0], chunk_id="foreign"),
+            "wrong_shared_doc": replace(shared.results[0], document_id="foreign"),
+            "duplicate_shared": shared.results[1],
+        }[fault]
+        inputs["shared_rerank_by_question_id"][qid] = replace(shared, results=(replacement, *shared.results[1:]))
+
+    def forbidden_loader(_):
+        pytest.fail("invalid frozen inputs reached corpus loading")
+
+    inputs["load_document_chunks"] = forbidden_loader
+    with pytest.raises(ValueError, match="Dense Top100|shared replay"):
+        runner(**inputs)
+
+
+def test_offline_preflight_rejects_foreign_loaded_chunks_even_beyond_capacity():
+    runner = _preflight_runner()
+    inputs = _preflight_inputs()
+    inputs["load_document_chunks"] = lambda doc: (
+        *(_chunk(f"{doc}-{i}", doc) for i in range(500)),
+        _chunk("foreign", "OUTSIDE"),
+    )
+    with pytest.raises(ValueError, match="loaded chunk"):
+        runner(**inputs)
+
+
+@pytest.mark.parametrize("fault", ["foreign", "duplicate", "wrong_document"])
+def test_offline_preflight_rejects_invalid_merged_replay(fault):
+    runner = _preflight_runner()
+    inputs = _preflight_inputs()
+    merged = inputs["merged_reranks_by_question_id"]["TRAIN_PREFLIGHT"]
+    replay = merged["g1"]
+    replacement = {
+        "foreign": replace(replay.results[-1], chunk_id="foreign"),
+        "duplicate": replay.results[0],
+        "wrong_document": replace(replay.results[-1], document_id="foreign"),
+    }[fault]
+    # Validate the entire replay, including invalid rows beyond Top16.
+    merged["g1"] = replace(replay, results=(*replay.results[:-1], replacement))
+    with pytest.raises(ValueError, match="merged replay"):
+        runner(**inputs)
+
+
+def test_offline_preflight_rejects_empty_case_set():
+    inputs = _preflight_inputs()
+    inputs["e0_trace_by_question_id"] = {}
+    with pytest.raises(ValueError, match="at least one frozen case"):
+        _preflight_runner()(**inputs)
+
+
+def test_offline_preflight_deduplicates_loaded_chunks_and_fingerprint_tracks_admission():
+    runner = _preflight_runner()
+    inputs = _preflight_inputs()
+    first = runner(**inputs)
+    loader = inputs["load_document_chunks"]
+    inputs["load_document_chunks"] = lambda doc: tuple(c for c in loader(doc) for _ in range(2))
+    assert runner(**inputs) == first
+    qid = "TRAIN_PREFLIGHT"
+    inputs["shared_rerank_by_question_id"][qid] = _replay(inputs["e0_trace_by_question_id"][qid])
+    inputs["merged_reranks_by_question_id"][qid]["g2"] = inputs["merged_reranks_by_question_id"][qid]["g1"]
+    changed = runner(**inputs)
+    assert changed["fingerprint_sha256"] != first["fingerprint_sha256"]
+    assert changed["cases"][0]["g2_admitted_doc_ids"] == ["D0", "D1", "D2", "D3", "D4"]
 
 
 def _g2_module():

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -5,7 +5,9 @@ import importlib.util
 
 import pytest
 
+from experiments.evals.eval_techqa_generation import G0RetrievedChunk
 from experiments.evals.rerankers.qwen3_reranker import (
+    RerankCandidate,
     RerankResult,
     RerankedCandidate,
 )
@@ -18,6 +20,12 @@ def _g2_module():
     spec = importlib.util.find_spec(MODULE_NAME)
     assert spec is not None, "eval_techqa_g2_admission is not implemented"
     return importlib.import_module(MODULE_NAME)
+
+
+def _g2_runner():
+    runner = getattr(_g2_module(), "run_g2_admission_diagnostic", None)
+    assert runner is not None, "run_g2_admission_diagnostic is not implemented"
+    return runner
 
 
 def _shared_rerank(*document_ids: str) -> RerankResult:
@@ -34,6 +42,22 @@ def _shared_rerank(*document_ids: str) -> RerankResult:
         ),
         request_id="shared-global-rerank",
         total_tokens=123,
+    )
+
+
+def _chunk(
+    chunk_id: str,
+    document_id: str,
+    *,
+    chunk_index: int = 0,
+    distance: float = 0.1,
+) -> G0RetrievedChunk:
+    return G0RetrievedChunk(
+        chunk_id=chunk_id,
+        document_id=document_id,
+        chunk_index=chunk_index,
+        content=f"content {chunk_id}",
+        distance=distance,
     )
 
 
@@ -65,3 +89,155 @@ def test_rerank_informed_admission_requires_positive_limit(limit: int):
 
     with pytest.raises(ValueError, match="limit must be positive"):
         selector(_shared_rerank("D1"), limit=limit)
+
+
+def test_g2_diagnostic_admits_global_rerank_docs_and_calls_merged_reranker_once():
+    runner = _g2_runner()
+    dense_ranked = tuple(
+        _chunk(f"dense-{index}", document_id, distance=index / 100.0)
+        for index, document_id in enumerate(("D1", "D2", "D3", "D4", "D5", "D9"))
+    )
+    shared_global_rerank = _shared_rerank("D9", "D8", "D7", "D6", "D5", "D4")
+    loader_calls: list[str] = []
+    chunks_by_document = {
+        document_id: (_chunk(f"{document_id}-chunk-0", document_id),)
+        for document_id in ("D9", "D8", "D7", "D6", "D5")
+    }
+    merged_calls: list[tuple[str, tuple[RerankCandidate, ...]]] = []
+
+    def load_document_chunks(document_id: str):
+        loader_calls.append(document_id)
+        return chunks_by_document[document_id]
+
+    def merged_reranker(question: str, candidates):
+        candidate_tuple = tuple(candidates)
+        merged_calls.append((question, candidate_tuple))
+        return RerankResult(
+            results=tuple(
+                RerankedCandidate(
+                    chunk_id=candidate.chunk_id,
+                    document_id=candidate.document_id,
+                    content=candidate.content,
+                    original_index=index,
+                    relevance_score=1.0 - index / 100.0,
+                )
+                for index, candidate in reversed(tuple(enumerate(candidate_tuple)))
+            ),
+            request_id="merged-rerank",
+            total_tokens=456,
+        )
+
+    diagnostic = runner(
+        "TRAIN_SYNTHETIC",
+        "Which evidence resolves the issue?",
+        dense_ranked,
+        shared_global_rerank=shared_global_rerank,
+        candidate_document_limit=5,
+        load_document_chunks=load_document_chunks,
+        candidate_pool_max_chunks=500,
+        merged_reranker=merged_reranker,
+        evidence_limit=16,
+        max_context_chunks=16,
+    )
+
+    assert diagnostic.candidate_document_ids == ("D9", "D8", "D7", "D6", "D5")
+    assert diagnostic.candidate_document_ids != ("D1", "D2", "D3", "D4", "D5")
+    assert loader_calls == ["D9", "D8", "D7", "D6", "D5"]
+    assert len(merged_calls) == 1
+    assert diagnostic.merged_rerank_invocations == 1
+    assert tuple(chunk.document_id for chunk in diagnostic.final_context) == (
+        "D5",
+        "D6",
+        "D7",
+        "D8",
+        "D9",
+    )
+
+
+def test_g2_diagnostic_reuses_existing_g1_downstream_helpers(monkeypatch):
+    module = _g2_module()
+    runner = _g2_runner()
+    calls: list[tuple[str, object]] = []
+    pool = (_chunk("pool-1", "D9"),)
+    selected = (_chunk("selected-1", "D9"),)
+    final = (_chunk("final-1", "D9"),)
+
+    def fake_pool_builder(candidate_document_ids, *, load_document_chunks, max_chunks):
+        calls.append(("pool", (tuple(candidate_document_ids), max_chunks)))
+        return pool
+
+    def fake_evidence_selector(question, candidate_pool, *, reranker, limit):
+        calls.append(("evidence", (question, tuple(candidate_pool), limit)))
+        return selected
+
+    def fake_assembler(selected_evidence, *, max_context_chunks):
+        calls.append(("assembly", (tuple(selected_evidence), max_context_chunks)))
+        return final
+
+    monkeypatch.setattr(module, "build_document_local_candidate_pool", fake_pool_builder, raising=False)
+    monkeypatch.setattr(module, "select_document_local_evidence", fake_evidence_selector, raising=False)
+    monkeypatch.setattr(module, "assemble_selected_evidence_context", fake_assembler, raising=False)
+
+    diagnostic = runner(
+        "TRAIN_HELPERS",
+        "question",
+        (_chunk("dense-1", "D1"),),
+        shared_global_rerank=_shared_rerank("D9"),
+        candidate_document_limit=5,
+        load_document_chunks=lambda _: (),
+        candidate_pool_max_chunks=500,
+        merged_reranker=lambda *_: None,
+        evidence_limit=16,
+        max_context_chunks=16,
+    )
+
+    assert calls == [
+        ("pool", (("D9",), 500)),
+        ("evidence", ("question", pool, 16)),
+        ("assembly", (selected, 16)),
+    ]
+    assert diagnostic.candidate_pool == pool
+    assert diagnostic.selected_evidence == selected
+    assert diagnostic.final_context == final
+
+
+@pytest.mark.parametrize(
+    "invalid_budget",
+    (
+        "candidate_document_limit",
+        "candidate_pool_max_chunks",
+        "evidence_limit",
+        "max_context_chunks",
+    ),
+)
+def test_g2_diagnostic_validates_all_budgets_before_side_effects(invalid_budget: str):
+    runner = _g2_runner()
+    side_effects: list[str] = []
+    budgets = {
+        "candidate_document_limit": 5,
+        "candidate_pool_max_chunks": 500,
+        "evidence_limit": 16,
+        "max_context_chunks": 16,
+    }
+    budgets[invalid_budget] = 0
+
+    def forbidden_loader(_: str):
+        side_effects.append("loader")
+        raise AssertionError("invalid budgets must fail before document loading")
+
+    def forbidden_reranker(*_):
+        side_effects.append("reranker")
+        raise AssertionError("invalid budgets must fail before reranking")
+
+    with pytest.raises(ValueError, match="positive"):
+        runner(
+            "TRAIN_INVALID",
+            "question",
+            (_chunk("dense-1", "D1"),),
+            shared_global_rerank=_shared_rerank("D9"),
+            load_document_chunks=forbidden_loader,
+            merged_reranker=forbidden_reranker,
+            **budgets,
+        )
+
+    assert side_effects == []

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import hashlib
 
 import pytest
 
+from experiments.evals.adapters.techqa import TechQAGenerationCase
 from experiments.evals.eval_techqa_generation import G0RetrievedChunk
 from experiments.evals.rerankers.qwen3_reranker import (
     RerankCandidate,
@@ -65,6 +67,116 @@ def _chunk(
         content=f"content {chunk_id}",
         distance=distance,
     )
+
+
+def _generation_case(
+    question_id: str,
+    *,
+    answerable: bool = True,
+    split: str = "train",
+) -> TechQAGenerationCase:
+    return TechQAGenerationCase(
+        question_id=question_id,
+        question=f"question {question_id}",
+        gold_answer="gold answer",
+        answerable=answerable,
+        split=split,  # type: ignore[arg-type]
+    )
+
+
+def _g2_preregistered_case_selector():
+    selector = getattr(_g2_module(), "select_g2_preregistered_cases", None)
+    assert selector is not None, "select_g2_preregistered_cases is not implemented"
+    return selector
+
+
+def test_g2_preregistered_selection_uses_only_eligible_train_cases_before_hashing():
+    selector = _g2_preregistered_case_selector()
+    cases = (
+        _generation_case("TRAIN_ELIGIBLE_DEEP"),
+        _generation_case("TRAIN_IMPOSSIBLE", answerable=False),
+        _generation_case("DEV_NON_TRAIN", split="dev"),
+        _generation_case("TRAIN_MISSING_TRACE"),
+        _generation_case("TRAIN_GOLD_ABSENT"),
+        _generation_case("TRAIN_EXCLUDED"),
+    )
+    traces = {
+        "TRAIN_ELIGIBLE_DEEP": (
+            _chunk("first", "other-document"),
+            _chunk("sixth", "gold-document"),
+        ),
+        "TRAIN_GOLD_ABSENT": (_chunk("only", "other-document"),),
+        "TRAIN_EXCLUDED": (_chunk("excluded", "gold-document"),),
+    }
+    relevant_documents = {
+        "TRAIN_ELIGIBLE_DEEP": "gold-document",
+        "TRAIN_GOLD_ABSENT": "gold-document",
+        "TRAIN_EXCLUDED": "gold-document",
+    }
+
+    assert selector(
+        cases,
+        e0_trace_by_question_id=traces,
+        relevant_document_by_question_id=relevant_documents,
+        excluded_question_ids={"TRAIN_EXCLUDED"},
+        sample_size=1,
+    ) == ("TRAIN_ELIGIBLE_DEEP",)
+
+
+def test_g2_preregistered_selection_hashes_eligible_ids_and_is_repeatable():
+    selector = _g2_preregistered_case_selector()
+    eligible_ids = tuple(f"TRAIN_Q{index:03d}" for index in range(31))
+    cases = tuple(_generation_case(question_id) for question_id in eligible_ids)
+    traces = {
+        question_id: (_chunk(f"{question_id}-chunk", "gold-document"),)
+        for question_id in eligible_ids
+    }
+    relevant_documents = {question_id: "gold-document" for question_id in eligible_ids}
+    excluded_question_ids = {"TRAIN_Q000"}
+    seed = "selection-seed"
+    expected = tuple(
+        sorted(
+            (question_id for question_id in eligible_ids if question_id not in excluded_question_ids),
+            key=lambda question_id: (
+                hashlib.sha256(f"{seed}:{question_id}".encode("utf-8")).hexdigest(),
+                question_id,
+            ),
+        )[:30]
+    )
+
+    first = selector(
+        cases,
+        e0_trace_by_question_id=traces,
+        relevant_document_by_question_id=relevant_documents,
+        excluded_question_ids=excluded_question_ids,
+        seed=seed,
+    )
+    second = selector(
+        cases,
+        e0_trace_by_question_id=traces,
+        relevant_document_by_question_id=relevant_documents,
+        excluded_question_ids=excluded_question_ids,
+        seed=seed,
+    )
+
+    assert first == second == expected
+    assert "TRAIN_Q000" not in first
+
+
+def test_g2_preregistered_selection_rejects_insufficient_eligible_population():
+    selector = _g2_preregistered_case_selector()
+    case = _generation_case("TRAIN_ONLY_CASE")
+
+    with pytest.raises(ValueError, match="Insufficient eligible"):
+        selector(
+            (case,),
+            e0_trace_by_question_id={
+                case.question_id: (_chunk("gold", "gold-document"),),
+            },
+            relevant_document_by_question_id={case.question_id: "gold-document"},
+            excluded_question_ids=(),
+            sample_size=2,
+        )
 
 
 def test_rerank_informed_admission_uses_first_unique_docs_in_rerank_order():

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -28,6 +28,12 @@ def _g2_runner():
     return runner
 
 
+def _comparison_runner():
+    runner = getattr(_g2_module(), "run_g1_g2_admission_comparison", None)
+    assert runner is not None, "run_g1_g2_admission_comparison is not implemented"
+    return runner
+
+
 def _shared_rerank(*document_ids: str) -> RerankResult:
     return RerankResult(
         results=tuple(
@@ -241,3 +247,144 @@ def test_g2_diagnostic_validates_all_budgets_before_side_effects(invalid_budget:
         )
 
     assert side_effects == []
+
+
+def test_g1_g2_comparison_changes_only_document_admission_order():
+    runner = _comparison_runner()
+    dense_ranked = tuple(
+        _chunk(f"dense-{index}", document_id, distance=index / 100.0)
+        for index, document_id in enumerate(("D1", "D2", "D3", "D4", "D5", "D9"))
+    )
+    shared_global_rerank = _shared_rerank("D9", "D8", "D7", "D6", "D5", "D4")
+    chunks_by_document = {
+        document_id: (_chunk(f"{document_id}-chunk-0", document_id),)
+        for document_id in ("D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8", "D9")
+    }
+
+    def load_document_chunks(document_id: str):
+        return chunks_by_document[document_id]
+
+    def merged_reranker(question: str, candidates):
+        candidate_tuple = tuple(candidates)
+        return RerankResult(
+            results=tuple(
+                RerankedCandidate(
+                    chunk_id=candidate.chunk_id,
+                    document_id=candidate.document_id,
+                    content=candidate.content,
+                    original_index=index,
+                    relevance_score=1.0 - index / 100.0,
+                )
+                for index, candidate in enumerate(candidate_tuple)
+            ),
+            request_id="merged-rerank",
+            total_tokens=456,
+        )
+
+    comparison = runner(
+        "TRAIN_CAUSAL",
+        "question",
+        dense_ranked,
+        shared_global_rerank=shared_global_rerank,
+        candidate_document_limit=5,
+        load_document_chunks=load_document_chunks,
+        candidate_pool_max_chunks=500,
+        merged_reranker=merged_reranker,
+        evidence_limit=16,
+        max_context_chunks=16,
+    )
+
+    assert comparison.question_id == "TRAIN_CAUSAL"
+    assert comparison.dense_candidate_chunk_ids == tuple(
+        chunk.chunk_id for chunk in dense_ranked
+    )
+    assert comparison.g1_candidate_document_ids == ("D1", "D2", "D3", "D4", "D5")
+    assert comparison.g2_candidate_document_ids == ("D9", "D8", "D7", "D6", "D5")
+    assert tuple(chunk.document_id for chunk in comparison.g1_context) == (
+        "D1", "D2", "D3", "D4", "D5"
+    )
+    assert tuple(chunk.document_id for chunk in comparison.g2_context) == (
+        "D9", "D8", "D7", "D6", "D5"
+    )
+
+
+def test_g1_g2_comparison_reuses_identical_downstream_contract(monkeypatch):
+    module = _g2_module()
+    runner = _comparison_runner()
+    dense_ranked = (
+        _chunk("dense-1", "D1"),
+        _chunk("dense-2", "D2"),
+    )
+    shared_global_rerank = _shared_rerank("D9", "D8")
+    calls: list[tuple[str, object]] = []
+
+    def load_document_chunks(document_id: str):
+        return (_chunk(f"{document_id}-loaded", document_id),)
+
+    def merged_reranker(question: str, candidates):
+        candidate_tuple = tuple(candidates)
+        return RerankResult(
+            results=tuple(
+                RerankedCandidate(
+                    chunk_id=candidate.chunk_id,
+                    document_id=candidate.document_id,
+                    content=candidate.content,
+                    original_index=index,
+                    relevance_score=1.0 - index / 100.0,
+                )
+                for index, candidate in enumerate(candidate_tuple)
+            ),
+            request_id="merged-rerank",
+            total_tokens=456,
+        )
+
+    def fake_pool_builder(candidate_document_ids, *, load_document_chunks, max_chunks):
+        document_ids = tuple(candidate_document_ids)
+        calls.append(("pool", (document_ids, load_document_chunks, max_chunks)))
+        return tuple(_chunk(f"{document_id}-pool", document_id) for document_id in document_ids)
+
+    def fake_evidence_selector(question, candidate_pool, *, reranker, limit):
+        pool = tuple(candidate_pool)
+        calls.append(("evidence", (question, pool, reranker, limit)))
+        return pool
+
+    def fake_assembler(selected_evidence, *, max_context_chunks):
+        selected = tuple(selected_evidence)
+        calls.append(("assembly", (selected, max_context_chunks)))
+        return selected
+
+    monkeypatch.setattr(module, "build_document_local_candidate_pool", fake_pool_builder, raising=False)
+    monkeypatch.setattr(module, "select_document_local_evidence", fake_evidence_selector, raising=False)
+    monkeypatch.setattr(module, "assemble_selected_evidence_context", fake_assembler, raising=False)
+
+    comparison = runner(
+        "TRAIN_CONTRACT",
+        "question",
+        dense_ranked,
+        shared_global_rerank=shared_global_rerank,
+        candidate_document_limit=5,
+        load_document_chunks=load_document_chunks,
+        candidate_pool_max_chunks=500,
+        merged_reranker=merged_reranker,
+        evidence_limit=16,
+        max_context_chunks=16,
+    )
+
+    assert comparison.g1_candidate_document_ids == ("D1", "D2")
+    assert comparison.g2_candidate_document_ids == ("D9", "D8")
+    assert len(calls) == 6
+
+    g1_pool_call, g1_evidence_call, g1_assembly_call = calls[:3]
+    g2_pool_call, g2_evidence_call, g2_assembly_call = calls[3:]
+
+    assert g1_pool_call[0] == g2_pool_call[0] == "pool"
+    assert g1_pool_call[1][1] is g2_pool_call[1][1] is load_document_chunks
+    assert g1_pool_call[1][2] == g2_pool_call[1][2] == 500
+
+    assert g1_evidence_call[0] == g2_evidence_call[0] == "evidence"
+    assert g1_evidence_call[1][0] == g2_evidence_call[1][0] == "question"
+    assert g1_evidence_call[1][2] is g2_evidence_call[1][2] is merged_reranker
+    assert g1_evidence_call[1][3] == g2_evidence_call[1][3] == 16
+
+    assert g1_assembly_call[0] == g2_assembly_call[0] == "assembly"
+    assert g1_assembly_call[1][1] == g2_assembly_call[1][1] == 16

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -95,21 +95,31 @@ def test_g2_preregistered_selection_uses_only_eligible_train_cases_before_hashin
     cases = (
         _generation_case("TRAIN_ELIGIBLE_DEEP"),
         _generation_case("TRAIN_IMPOSSIBLE", answerable=False),
-        _generation_case("DEV_NON_TRAIN", split="dev"),
+        _generation_case("TRAIN_NON_TRAIN_SPLIT", split="dev"),
         _generation_case("TRAIN_MISSING_TRACE"),
         _generation_case("TRAIN_GOLD_ABSENT"),
         _generation_case("TRAIN_EXCLUDED"),
     )
     traces = {
         "TRAIN_ELIGIBLE_DEEP": (
-            _chunk("first", "other-document"),
+            _chunk("first", "other-document-1"),
+            _chunk("second", "other-document-2"),
+            _chunk("third", "other-document-3"),
+            _chunk("fourth", "other-document-4"),
+            _chunk("fifth", "other-document-5"),
             _chunk("sixth", "gold-document"),
+        ),
+        "TRAIN_IMPOSSIBLE": (_chunk("impossible", "gold-document"),),
+        "TRAIN_NON_TRAIN_SPLIT": (
+            _chunk("non-train", "gold-document"),
         ),
         "TRAIN_GOLD_ABSENT": (_chunk("only", "other-document"),),
         "TRAIN_EXCLUDED": (_chunk("excluded", "gold-document"),),
     }
     relevant_documents = {
         "TRAIN_ELIGIBLE_DEEP": "gold-document",
+        "TRAIN_IMPOSSIBLE": "gold-document",
+        "TRAIN_NON_TRAIN_SPLIT": "gold-document",
         "TRAIN_GOLD_ABSENT": "gold-document",
         "TRAIN_EXCLUDED": "gold-document",
     }

--- a/tests/test_eval_techqa_g2_admission.py
+++ b/tests/test_eval_techqa_g2_admission.py
@@ -286,12 +286,8 @@ def test_g1_g2_comparison_changes_only_document_admission_order():
         "question",
         dense_ranked,
         shared_global_rerank=shared_global_rerank,
-        candidate_document_limit=5,
         load_document_chunks=load_document_chunks,
-        candidate_pool_max_chunks=500,
         merged_reranker=merged_reranker,
-        evidence_limit=16,
-        max_context_chunks=16,
     )
 
     assert comparison.question_id == "TRAIN_CAUSAL"
@@ -362,12 +358,8 @@ def test_g1_g2_comparison_reuses_identical_downstream_contract(monkeypatch):
         "question",
         dense_ranked,
         shared_global_rerank=shared_global_rerank,
-        candidate_document_limit=5,
         load_document_chunks=load_document_chunks,
-        candidate_pool_max_chunks=500,
         merged_reranker=merged_reranker,
-        evidence_limit=16,
-        max_context_chunks=16,
     )
 
     assert comparison.g1_candidate_document_ids == ("D1", "D2")


### PR DESCRIPTION
## Summary

- add G2-A rerank-informed document-admission evaluation path
- compare Dense-order G1 admission against global-rerank-informed G2-A admission under a frozen 5-document / Top16 evidence contract
- freeze deterministic sampling, preflight, execution, blinded evidence-sufficiency review, and preregistered GO/NO_GO decision
- document the post-hoc movement analysis without promoting it to confirmatory evidence

## Result

G2-A final decision: **NO_GO**

| Metric | G1 | G2-A |
| --- | ---: | ---: |
| COMPLETE | 19 | 19 |
| PARTIAL | 2 | 1 |
| INSUFFICIENT | 9 | 10 |
| UNRESOLVED | 0 | 0 |
| Macro claim coverage | 0.666667 | 0.650000 |

Pairwise:
- wins: 2
- ties: 25
- losses: 3
- catastrophic regressions: 2

G2-A failed the preregistered gates for:
- insufficient count
- macro claim coverage
- wins > losses
- catastrophic regressions = 0

E1 remains the reference policy.
G1 and G2-A remain experimental NO_GO branches.

## Post-hoc diagnosis

The five movement cases suggest that document-admission ranking is the dominant mechanism, with the fixed 5-document budget acting as an amplifier:

- 2 G2 wins rescued the gold document into admission
- 2 catastrophic regressions displaced a gold document that G1 admitted
- 1 additional regression changed admission-set composition while both arms missed the gold document

This analysis is explicitly post-hoc and is not confirmatory evidence for a new policy.

No G3 is proposed by this PR.

## Scope boundaries

This PR does not claim:
- frozen DEV generation improvement
- production generation accuracy uplift
- production latency or cost improvement
- that global reranking is generally harmful

It rejects only the tested rerank-informed five-document admission policy.

## Verification

Fresh local verification before commit:

- `python -m pytest -q`
  - 376 passed, 2 warnings
- `ruff check .`
  - All checks passed
- `git diff --check`
  - PASS